### PR TITLE
add group types

### DIFF
--- a/src/regen/group/v1alpha1/genesis.ts
+++ b/src/regen/group/v1alpha1/genesis.ts
@@ -1,0 +1,304 @@
+/* eslint-disable */
+import Long from "long";
+import _m0 from "protobufjs/minimal";
+import {
+  GroupInfo,
+  GroupMember,
+  GroupAccountInfo,
+  Proposal,
+  Vote,
+} from "../../../regen/group/v1alpha1/types";
+
+export const protobufPackage = "regen.group.v1alpha1";
+
+/** GenesisState defines the group module's genesis state. */
+export interface GenesisState {
+  /**
+   * group_seq is the group table orm.Sequence,
+   * it is used to get the next group ID.
+   */
+  groupSeq: Long;
+  /** groups is the list of groups info. */
+  groups: GroupInfo[];
+  /** group_members is the list of groups members. */
+  groupMembers: GroupMember[];
+  /**
+   * group_account_seq is the group account table orm.Sequence,
+   * it is used to generate the next group account address.
+   */
+  groupAccountSeq: Long;
+  /** group_accounts is the list of group accounts info. */
+  groupAccounts: GroupAccountInfo[];
+  /**
+   * proposal_seq is the proposal table orm.Sequence,
+   * it is used to get the next proposal ID.
+   */
+  proposalSeq: Long;
+  /** proposals is the list of proposals. */
+  proposals: Proposal[];
+  /** votes is the list of votes. */
+  votes: Vote[];
+}
+
+const baseGenesisState: object = {
+  groupSeq: Long.UZERO,
+  groupAccountSeq: Long.UZERO,
+  proposalSeq: Long.UZERO,
+};
+
+export const GenesisState = {
+  encode(
+    message: GenesisState,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (!message.groupSeq.isZero()) {
+      writer.uint32(8).uint64(message.groupSeq);
+    }
+    for (const v of message.groups) {
+      GroupInfo.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    for (const v of message.groupMembers) {
+      GroupMember.encode(v!, writer.uint32(26).fork()).ldelim();
+    }
+    if (!message.groupAccountSeq.isZero()) {
+      writer.uint32(32).uint64(message.groupAccountSeq);
+    }
+    for (const v of message.groupAccounts) {
+      GroupAccountInfo.encode(v!, writer.uint32(42).fork()).ldelim();
+    }
+    if (!message.proposalSeq.isZero()) {
+      writer.uint32(48).uint64(message.proposalSeq);
+    }
+    for (const v of message.proposals) {
+      Proposal.encode(v!, writer.uint32(58).fork()).ldelim();
+    }
+    for (const v of message.votes) {
+      Vote.encode(v!, writer.uint32(66).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): GenesisState {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseGenesisState } as GenesisState;
+    message.groups = [];
+    message.groupMembers = [];
+    message.groupAccounts = [];
+    message.proposals = [];
+    message.votes = [];
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.groupSeq = reader.uint64() as Long;
+          break;
+        case 2:
+          message.groups.push(GroupInfo.decode(reader, reader.uint32()));
+          break;
+        case 3:
+          message.groupMembers.push(
+            GroupMember.decode(reader, reader.uint32())
+          );
+          break;
+        case 4:
+          message.groupAccountSeq = reader.uint64() as Long;
+          break;
+        case 5:
+          message.groupAccounts.push(
+            GroupAccountInfo.decode(reader, reader.uint32())
+          );
+          break;
+        case 6:
+          message.proposalSeq = reader.uint64() as Long;
+          break;
+        case 7:
+          message.proposals.push(Proposal.decode(reader, reader.uint32()));
+          break;
+        case 8:
+          message.votes.push(Vote.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GenesisState {
+    const message = { ...baseGenesisState } as GenesisState;
+    message.groups = [];
+    message.groupMembers = [];
+    message.groupAccounts = [];
+    message.proposals = [];
+    message.votes = [];
+    if (object.groupSeq !== undefined && object.groupSeq !== null) {
+      message.groupSeq = Long.fromString(object.groupSeq);
+    } else {
+      message.groupSeq = Long.UZERO;
+    }
+    if (object.groups !== undefined && object.groups !== null) {
+      for (const e of object.groups) {
+        message.groups.push(GroupInfo.fromJSON(e));
+      }
+    }
+    if (object.groupMembers !== undefined && object.groupMembers !== null) {
+      for (const e of object.groupMembers) {
+        message.groupMembers.push(GroupMember.fromJSON(e));
+      }
+    }
+    if (
+      object.groupAccountSeq !== undefined &&
+      object.groupAccountSeq !== null
+    ) {
+      message.groupAccountSeq = Long.fromString(object.groupAccountSeq);
+    } else {
+      message.groupAccountSeq = Long.UZERO;
+    }
+    if (object.groupAccounts !== undefined && object.groupAccounts !== null) {
+      for (const e of object.groupAccounts) {
+        message.groupAccounts.push(GroupAccountInfo.fromJSON(e));
+      }
+    }
+    if (object.proposalSeq !== undefined && object.proposalSeq !== null) {
+      message.proposalSeq = Long.fromString(object.proposalSeq);
+    } else {
+      message.proposalSeq = Long.UZERO;
+    }
+    if (object.proposals !== undefined && object.proposals !== null) {
+      for (const e of object.proposals) {
+        message.proposals.push(Proposal.fromJSON(e));
+      }
+    }
+    if (object.votes !== undefined && object.votes !== null) {
+      for (const e of object.votes) {
+        message.votes.push(Vote.fromJSON(e));
+      }
+    }
+    return message;
+  },
+
+  toJSON(message: GenesisState): unknown {
+    const obj: any = {};
+    message.groupSeq !== undefined &&
+      (obj.groupSeq = (message.groupSeq || Long.UZERO).toString());
+    if (message.groups) {
+      obj.groups = message.groups.map((e) =>
+        e ? GroupInfo.toJSON(e) : undefined
+      );
+    } else {
+      obj.groups = [];
+    }
+    if (message.groupMembers) {
+      obj.groupMembers = message.groupMembers.map((e) =>
+        e ? GroupMember.toJSON(e) : undefined
+      );
+    } else {
+      obj.groupMembers = [];
+    }
+    message.groupAccountSeq !== undefined &&
+      (obj.groupAccountSeq = (
+        message.groupAccountSeq || Long.UZERO
+      ).toString());
+    if (message.groupAccounts) {
+      obj.groupAccounts = message.groupAccounts.map((e) =>
+        e ? GroupAccountInfo.toJSON(e) : undefined
+      );
+    } else {
+      obj.groupAccounts = [];
+    }
+    message.proposalSeq !== undefined &&
+      (obj.proposalSeq = (message.proposalSeq || Long.UZERO).toString());
+    if (message.proposals) {
+      obj.proposals = message.proposals.map((e) =>
+        e ? Proposal.toJSON(e) : undefined
+      );
+    } else {
+      obj.proposals = [];
+    }
+    if (message.votes) {
+      obj.votes = message.votes.map((e) => (e ? Vote.toJSON(e) : undefined));
+    } else {
+      obj.votes = [];
+    }
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<GenesisState>): GenesisState {
+    const message = { ...baseGenesisState } as GenesisState;
+    message.groups = [];
+    message.groupMembers = [];
+    message.groupAccounts = [];
+    message.proposals = [];
+    message.votes = [];
+    if (object.groupSeq !== undefined && object.groupSeq !== null) {
+      message.groupSeq = object.groupSeq as Long;
+    } else {
+      message.groupSeq = Long.UZERO;
+    }
+    if (object.groups !== undefined && object.groups !== null) {
+      for (const e of object.groups) {
+        message.groups.push(GroupInfo.fromPartial(e));
+      }
+    }
+    if (object.groupMembers !== undefined && object.groupMembers !== null) {
+      for (const e of object.groupMembers) {
+        message.groupMembers.push(GroupMember.fromPartial(e));
+      }
+    }
+    if (
+      object.groupAccountSeq !== undefined &&
+      object.groupAccountSeq !== null
+    ) {
+      message.groupAccountSeq = object.groupAccountSeq as Long;
+    } else {
+      message.groupAccountSeq = Long.UZERO;
+    }
+    if (object.groupAccounts !== undefined && object.groupAccounts !== null) {
+      for (const e of object.groupAccounts) {
+        message.groupAccounts.push(GroupAccountInfo.fromPartial(e));
+      }
+    }
+    if (object.proposalSeq !== undefined && object.proposalSeq !== null) {
+      message.proposalSeq = object.proposalSeq as Long;
+    } else {
+      message.proposalSeq = Long.UZERO;
+    }
+    if (object.proposals !== undefined && object.proposals !== null) {
+      for (const e of object.proposals) {
+        message.proposals.push(Proposal.fromPartial(e));
+      }
+    }
+    if (object.votes !== undefined && object.votes !== null) {
+      for (const e of object.votes) {
+        message.votes.push(Vote.fromPartial(e));
+      }
+    }
+    return message;
+  },
+};
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined
+  | Long;
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : T extends {}
+  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}

--- a/src/regen/group/v1alpha1/query.ts
+++ b/src/regen/group/v1alpha1/query.ts
@@ -1,0 +1,2311 @@
+/* eslint-disable */
+import Long from "long";
+import _m0 from "protobufjs/minimal";
+import {
+  GroupInfo,
+  GroupAccountInfo,
+  Proposal,
+  Vote,
+  GroupMember,
+} from "../../../regen/group/v1alpha1/types";
+import {
+  PageRequest,
+  PageResponse,
+} from "../../../cosmos/base/query/v1beta1/pagination";
+
+export const protobufPackage = "regen.group.v1alpha1";
+
+/** QueryGroupInfoRequest is the Query/GroupInfo request type. */
+export interface QueryGroupInfoRequest {
+  /** group_id is the unique ID of the group. */
+  groupId: Long;
+}
+
+/** QueryGroupInfoResponse is the Query/GroupInfo response type. */
+export interface QueryGroupInfoResponse {
+  /** info is the GroupInfo for the group. */
+  info?: GroupInfo;
+}
+
+/** QueryGroupAccountInfoRequest is the Query/GroupAccountInfo request type. */
+export interface QueryGroupAccountInfoRequest {
+  /** address is the account address of the group account. */
+  address: string;
+}
+
+/** QueryGroupAccountInfoResponse is the Query/GroupAccountInfo response type. */
+export interface QueryGroupAccountInfoResponse {
+  /** info is the GroupAccountInfo for the group account. */
+  info?: GroupAccountInfo;
+}
+
+/** QueryGroupMembersRequest is the Query/GroupMembersRequest request type. */
+export interface QueryGroupMembersRequest {
+  /** group_id is the unique ID of the group. */
+  groupId: Long;
+  /** pagination defines an optional pagination for the request. */
+  pagination?: PageRequest;
+}
+
+/** QueryGroupMembersResponse is the Query/GroupMembersResponse response type. */
+export interface QueryGroupMembersResponse {
+  /** members are the members of the group with given group_id. */
+  members: GroupMember[];
+  /** pagination defines the pagination in the response. */
+  pagination?: PageResponse;
+}
+
+/** QueryGroupsByAdminRequest is the Query/GroupsByAdminRequest request type. */
+export interface QueryGroupsByAdminRequest {
+  /** admin is the account address of a group's admin. */
+  admin: string;
+  /** pagination defines an optional pagination for the request. */
+  pagination?: PageRequest;
+}
+
+/** QueryGroupsByAdminResponse is the Query/GroupsByAdminResponse response type. */
+export interface QueryGroupsByAdminResponse {
+  /** groups are the groups info with the provided admin. */
+  groups: GroupInfo[];
+  /** pagination defines the pagination in the response. */
+  pagination?: PageResponse;
+}
+
+/** QueryGroupAccountsByGroupRequest is the Query/GroupAccountsByGroup request type. */
+export interface QueryGroupAccountsByGroupRequest {
+  /** group_id is the unique ID of the group account's group. */
+  groupId: Long;
+  /** pagination defines an optional pagination for the request. */
+  pagination?: PageRequest;
+}
+
+/** QueryGroupAccountsByGroupResponse is the Query/GroupAccountsByGroup response type. */
+export interface QueryGroupAccountsByGroupResponse {
+  /** group_accounts are the group accounts info associated with the provided group. */
+  groupAccounts: GroupAccountInfo[];
+  /** pagination defines the pagination in the response. */
+  pagination?: PageResponse;
+}
+
+/** QueryGroupAccountsByAdminRequest is the Query/GroupAccountsByAdmin request type. */
+export interface QueryGroupAccountsByAdminRequest {
+  /** admin is the admin address of the group account. */
+  admin: string;
+  /** pagination defines an optional pagination for the request. */
+  pagination?: PageRequest;
+}
+
+/** QueryGroupAccountsByAdminResponse is the Query/GroupAccountsByAdmin response type. */
+export interface QueryGroupAccountsByAdminResponse {
+  /** group_accounts are the group accounts info with provided admin. */
+  groupAccounts: GroupAccountInfo[];
+  /** pagination defines the pagination in the response. */
+  pagination?: PageResponse;
+}
+
+/** QueryProposalRequest is the Query/Proposal request type. */
+export interface QueryProposalRequest {
+  /** proposal_id is the unique ID of a proposal. */
+  proposalId: Long;
+}
+
+/** QueryProposalResponse is the Query/Proposal response type. */
+export interface QueryProposalResponse {
+  /** proposal is the proposal info. */
+  proposal?: Proposal;
+}
+
+/** QueryProposalsByGroupAccountRequest is the Query/ProposalByGroupAccount request type. */
+export interface QueryProposalsByGroupAccountRequest {
+  /** address is the group account address related to proposals. */
+  address: string;
+  /** pagination defines an optional pagination for the request. */
+  pagination?: PageRequest;
+}
+
+/** QueryProposalsByGroupAccountResponse is the Query/ProposalByGroupAccount response type. */
+export interface QueryProposalsByGroupAccountResponse {
+  /** proposals are the proposals with given group account. */
+  proposals: Proposal[];
+  /** pagination defines the pagination in the response. */
+  pagination?: PageResponse;
+}
+
+/** QueryVoteByProposalVoterResponse is the Query/VoteByProposalVoter request type. */
+export interface QueryVoteByProposalVoterRequest {
+  /** proposal_id is the unique ID of a proposal. */
+  proposalId: Long;
+  /** voter is a proposal voter account address. */
+  voter: string;
+}
+
+/** QueryVoteByProposalVoterResponse is the Query/VoteByProposalVoter response type. */
+export interface QueryVoteByProposalVoterResponse {
+  /** vote is the vote with given proposal_id and voter. */
+  vote?: Vote;
+}
+
+/** QueryVotesByProposalResponse is the Query/VotesByProposal request type. */
+export interface QueryVotesByProposalRequest {
+  /** proposal_id is the unique ID of a proposal. */
+  proposalId: Long;
+  /** pagination defines an optional pagination for the request. */
+  pagination?: PageRequest;
+}
+
+/** QueryVotesByProposalResponse is the Query/VotesByProposal response type. */
+export interface QueryVotesByProposalResponse {
+  /** votes are the list of votes for given proposal_id. */
+  votes: Vote[];
+  /** pagination defines the pagination in the response. */
+  pagination?: PageResponse;
+}
+
+/** QueryVotesByVoterResponse is the Query/VotesByVoter request type. */
+export interface QueryVotesByVoterRequest {
+  /** voter is a proposal voter account address. */
+  voter: string;
+  /** pagination defines an optional pagination for the request. */
+  pagination?: PageRequest;
+}
+
+/** QueryVotesByVoterResponse is the Query/VotesByVoter response type. */
+export interface QueryVotesByVoterResponse {
+  /** votes are the list of votes by given voter. */
+  votes: Vote[];
+  /** pagination defines the pagination in the response. */
+  pagination?: PageResponse;
+}
+
+const baseQueryGroupInfoRequest: object = { groupId: Long.UZERO };
+
+export const QueryGroupInfoRequest = {
+  encode(
+    message: QueryGroupInfoRequest,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (!message.groupId.isZero()) {
+      writer.uint32(8).uint64(message.groupId);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryGroupInfoRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseQueryGroupInfoRequest } as QueryGroupInfoRequest;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.groupId = reader.uint64() as Long;
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryGroupInfoRequest {
+    const message = { ...baseQueryGroupInfoRequest } as QueryGroupInfoRequest;
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = Long.fromString(object.groupId);
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    return message;
+  },
+
+  toJSON(message: QueryGroupInfoRequest): unknown {
+    const obj: any = {};
+    message.groupId !== undefined &&
+      (obj.groupId = (message.groupId || Long.UZERO).toString());
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryGroupInfoRequest>
+  ): QueryGroupInfoRequest {
+    const message = { ...baseQueryGroupInfoRequest } as QueryGroupInfoRequest;
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = object.groupId as Long;
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    return message;
+  },
+};
+
+const baseQueryGroupInfoResponse: object = {};
+
+export const QueryGroupInfoResponse = {
+  encode(
+    message: QueryGroupInfoResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.info !== undefined) {
+      GroupInfo.encode(message.info, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryGroupInfoResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseQueryGroupInfoResponse } as QueryGroupInfoResponse;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.info = GroupInfo.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryGroupInfoResponse {
+    const message = { ...baseQueryGroupInfoResponse } as QueryGroupInfoResponse;
+    if (object.info !== undefined && object.info !== null) {
+      message.info = GroupInfo.fromJSON(object.info);
+    } else {
+      message.info = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: QueryGroupInfoResponse): unknown {
+    const obj: any = {};
+    message.info !== undefined &&
+      (obj.info = message.info ? GroupInfo.toJSON(message.info) : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryGroupInfoResponse>
+  ): QueryGroupInfoResponse {
+    const message = { ...baseQueryGroupInfoResponse } as QueryGroupInfoResponse;
+    if (object.info !== undefined && object.info !== null) {
+      message.info = GroupInfo.fromPartial(object.info);
+    } else {
+      message.info = undefined;
+    }
+    return message;
+  },
+};
+
+const baseQueryGroupAccountInfoRequest: object = { address: "" };
+
+export const QueryGroupAccountInfoRequest = {
+  encode(
+    message: QueryGroupAccountInfoRequest,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.address !== "") {
+      writer.uint32(10).string(message.address);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryGroupAccountInfoRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseQueryGroupAccountInfoRequest,
+    } as QueryGroupAccountInfoRequest;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.address = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryGroupAccountInfoRequest {
+    const message = {
+      ...baseQueryGroupAccountInfoRequest,
+    } as QueryGroupAccountInfoRequest;
+    if (object.address !== undefined && object.address !== null) {
+      message.address = String(object.address);
+    } else {
+      message.address = "";
+    }
+    return message;
+  },
+
+  toJSON(message: QueryGroupAccountInfoRequest): unknown {
+    const obj: any = {};
+    message.address !== undefined && (obj.address = message.address);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryGroupAccountInfoRequest>
+  ): QueryGroupAccountInfoRequest {
+    const message = {
+      ...baseQueryGroupAccountInfoRequest,
+    } as QueryGroupAccountInfoRequest;
+    if (object.address !== undefined && object.address !== null) {
+      message.address = object.address;
+    } else {
+      message.address = "";
+    }
+    return message;
+  },
+};
+
+const baseQueryGroupAccountInfoResponse: object = {};
+
+export const QueryGroupAccountInfoResponse = {
+  encode(
+    message: QueryGroupAccountInfoResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.info !== undefined) {
+      GroupAccountInfo.encode(message.info, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryGroupAccountInfoResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseQueryGroupAccountInfoResponse,
+    } as QueryGroupAccountInfoResponse;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.info = GroupAccountInfo.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryGroupAccountInfoResponse {
+    const message = {
+      ...baseQueryGroupAccountInfoResponse,
+    } as QueryGroupAccountInfoResponse;
+    if (object.info !== undefined && object.info !== null) {
+      message.info = GroupAccountInfo.fromJSON(object.info);
+    } else {
+      message.info = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: QueryGroupAccountInfoResponse): unknown {
+    const obj: any = {};
+    message.info !== undefined &&
+      (obj.info = message.info
+        ? GroupAccountInfo.toJSON(message.info)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryGroupAccountInfoResponse>
+  ): QueryGroupAccountInfoResponse {
+    const message = {
+      ...baseQueryGroupAccountInfoResponse,
+    } as QueryGroupAccountInfoResponse;
+    if (object.info !== undefined && object.info !== null) {
+      message.info = GroupAccountInfo.fromPartial(object.info);
+    } else {
+      message.info = undefined;
+    }
+    return message;
+  },
+};
+
+const baseQueryGroupMembersRequest: object = { groupId: Long.UZERO };
+
+export const QueryGroupMembersRequest = {
+  encode(
+    message: QueryGroupMembersRequest,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (!message.groupId.isZero()) {
+      writer.uint32(8).uint64(message.groupId);
+    }
+    if (message.pagination !== undefined) {
+      PageRequest.encode(message.pagination, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryGroupMembersRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseQueryGroupMembersRequest,
+    } as QueryGroupMembersRequest;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.groupId = reader.uint64() as Long;
+          break;
+        case 2:
+          message.pagination = PageRequest.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryGroupMembersRequest {
+    const message = {
+      ...baseQueryGroupMembersRequest,
+    } as QueryGroupMembersRequest;
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = Long.fromString(object.groupId);
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageRequest.fromJSON(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: QueryGroupMembersRequest): unknown {
+    const obj: any = {};
+    message.groupId !== undefined &&
+      (obj.groupId = (message.groupId || Long.UZERO).toString());
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryGroupMembersRequest>
+  ): QueryGroupMembersRequest {
+    const message = {
+      ...baseQueryGroupMembersRequest,
+    } as QueryGroupMembersRequest;
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = object.groupId as Long;
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageRequest.fromPartial(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+};
+
+const baseQueryGroupMembersResponse: object = {};
+
+export const QueryGroupMembersResponse = {
+  encode(
+    message: QueryGroupMembersResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    for (const v of message.members) {
+      GroupMember.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.pagination !== undefined) {
+      PageResponse.encode(
+        message.pagination,
+        writer.uint32(18).fork()
+      ).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryGroupMembersResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseQueryGroupMembersResponse,
+    } as QueryGroupMembersResponse;
+    message.members = [];
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.members.push(GroupMember.decode(reader, reader.uint32()));
+          break;
+        case 2:
+          message.pagination = PageResponse.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryGroupMembersResponse {
+    const message = {
+      ...baseQueryGroupMembersResponse,
+    } as QueryGroupMembersResponse;
+    message.members = [];
+    if (object.members !== undefined && object.members !== null) {
+      for (const e of object.members) {
+        message.members.push(GroupMember.fromJSON(e));
+      }
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageResponse.fromJSON(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: QueryGroupMembersResponse): unknown {
+    const obj: any = {};
+    if (message.members) {
+      obj.members = message.members.map((e) =>
+        e ? GroupMember.toJSON(e) : undefined
+      );
+    } else {
+      obj.members = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryGroupMembersResponse>
+  ): QueryGroupMembersResponse {
+    const message = {
+      ...baseQueryGroupMembersResponse,
+    } as QueryGroupMembersResponse;
+    message.members = [];
+    if (object.members !== undefined && object.members !== null) {
+      for (const e of object.members) {
+        message.members.push(GroupMember.fromPartial(e));
+      }
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageResponse.fromPartial(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+};
+
+const baseQueryGroupsByAdminRequest: object = { admin: "" };
+
+export const QueryGroupsByAdminRequest = {
+  encode(
+    message: QueryGroupsByAdminRequest,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.admin !== "") {
+      writer.uint32(10).string(message.admin);
+    }
+    if (message.pagination !== undefined) {
+      PageRequest.encode(message.pagination, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryGroupsByAdminRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseQueryGroupsByAdminRequest,
+    } as QueryGroupsByAdminRequest;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.admin = reader.string();
+          break;
+        case 2:
+          message.pagination = PageRequest.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryGroupsByAdminRequest {
+    const message = {
+      ...baseQueryGroupsByAdminRequest,
+    } as QueryGroupsByAdminRequest;
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = String(object.admin);
+    } else {
+      message.admin = "";
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageRequest.fromJSON(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: QueryGroupsByAdminRequest): unknown {
+    const obj: any = {};
+    message.admin !== undefined && (obj.admin = message.admin);
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryGroupsByAdminRequest>
+  ): QueryGroupsByAdminRequest {
+    const message = {
+      ...baseQueryGroupsByAdminRequest,
+    } as QueryGroupsByAdminRequest;
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = object.admin;
+    } else {
+      message.admin = "";
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageRequest.fromPartial(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+};
+
+const baseQueryGroupsByAdminResponse: object = {};
+
+export const QueryGroupsByAdminResponse = {
+  encode(
+    message: QueryGroupsByAdminResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    for (const v of message.groups) {
+      GroupInfo.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.pagination !== undefined) {
+      PageResponse.encode(
+        message.pagination,
+        writer.uint32(18).fork()
+      ).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryGroupsByAdminResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseQueryGroupsByAdminResponse,
+    } as QueryGroupsByAdminResponse;
+    message.groups = [];
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.groups.push(GroupInfo.decode(reader, reader.uint32()));
+          break;
+        case 2:
+          message.pagination = PageResponse.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryGroupsByAdminResponse {
+    const message = {
+      ...baseQueryGroupsByAdminResponse,
+    } as QueryGroupsByAdminResponse;
+    message.groups = [];
+    if (object.groups !== undefined && object.groups !== null) {
+      for (const e of object.groups) {
+        message.groups.push(GroupInfo.fromJSON(e));
+      }
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageResponse.fromJSON(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: QueryGroupsByAdminResponse): unknown {
+    const obj: any = {};
+    if (message.groups) {
+      obj.groups = message.groups.map((e) =>
+        e ? GroupInfo.toJSON(e) : undefined
+      );
+    } else {
+      obj.groups = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryGroupsByAdminResponse>
+  ): QueryGroupsByAdminResponse {
+    const message = {
+      ...baseQueryGroupsByAdminResponse,
+    } as QueryGroupsByAdminResponse;
+    message.groups = [];
+    if (object.groups !== undefined && object.groups !== null) {
+      for (const e of object.groups) {
+        message.groups.push(GroupInfo.fromPartial(e));
+      }
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageResponse.fromPartial(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+};
+
+const baseQueryGroupAccountsByGroupRequest: object = { groupId: Long.UZERO };
+
+export const QueryGroupAccountsByGroupRequest = {
+  encode(
+    message: QueryGroupAccountsByGroupRequest,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (!message.groupId.isZero()) {
+      writer.uint32(8).uint64(message.groupId);
+    }
+    if (message.pagination !== undefined) {
+      PageRequest.encode(message.pagination, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryGroupAccountsByGroupRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseQueryGroupAccountsByGroupRequest,
+    } as QueryGroupAccountsByGroupRequest;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.groupId = reader.uint64() as Long;
+          break;
+        case 2:
+          message.pagination = PageRequest.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryGroupAccountsByGroupRequest {
+    const message = {
+      ...baseQueryGroupAccountsByGroupRequest,
+    } as QueryGroupAccountsByGroupRequest;
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = Long.fromString(object.groupId);
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageRequest.fromJSON(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: QueryGroupAccountsByGroupRequest): unknown {
+    const obj: any = {};
+    message.groupId !== undefined &&
+      (obj.groupId = (message.groupId || Long.UZERO).toString());
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryGroupAccountsByGroupRequest>
+  ): QueryGroupAccountsByGroupRequest {
+    const message = {
+      ...baseQueryGroupAccountsByGroupRequest,
+    } as QueryGroupAccountsByGroupRequest;
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = object.groupId as Long;
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageRequest.fromPartial(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+};
+
+const baseQueryGroupAccountsByGroupResponse: object = {};
+
+export const QueryGroupAccountsByGroupResponse = {
+  encode(
+    message: QueryGroupAccountsByGroupResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    for (const v of message.groupAccounts) {
+      GroupAccountInfo.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.pagination !== undefined) {
+      PageResponse.encode(
+        message.pagination,
+        writer.uint32(18).fork()
+      ).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryGroupAccountsByGroupResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseQueryGroupAccountsByGroupResponse,
+    } as QueryGroupAccountsByGroupResponse;
+    message.groupAccounts = [];
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.groupAccounts.push(
+            GroupAccountInfo.decode(reader, reader.uint32())
+          );
+          break;
+        case 2:
+          message.pagination = PageResponse.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryGroupAccountsByGroupResponse {
+    const message = {
+      ...baseQueryGroupAccountsByGroupResponse,
+    } as QueryGroupAccountsByGroupResponse;
+    message.groupAccounts = [];
+    if (object.groupAccounts !== undefined && object.groupAccounts !== null) {
+      for (const e of object.groupAccounts) {
+        message.groupAccounts.push(GroupAccountInfo.fromJSON(e));
+      }
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageResponse.fromJSON(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: QueryGroupAccountsByGroupResponse): unknown {
+    const obj: any = {};
+    if (message.groupAccounts) {
+      obj.groupAccounts = message.groupAccounts.map((e) =>
+        e ? GroupAccountInfo.toJSON(e) : undefined
+      );
+    } else {
+      obj.groupAccounts = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryGroupAccountsByGroupResponse>
+  ): QueryGroupAccountsByGroupResponse {
+    const message = {
+      ...baseQueryGroupAccountsByGroupResponse,
+    } as QueryGroupAccountsByGroupResponse;
+    message.groupAccounts = [];
+    if (object.groupAccounts !== undefined && object.groupAccounts !== null) {
+      for (const e of object.groupAccounts) {
+        message.groupAccounts.push(GroupAccountInfo.fromPartial(e));
+      }
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageResponse.fromPartial(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+};
+
+const baseQueryGroupAccountsByAdminRequest: object = { admin: "" };
+
+export const QueryGroupAccountsByAdminRequest = {
+  encode(
+    message: QueryGroupAccountsByAdminRequest,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.admin !== "") {
+      writer.uint32(10).string(message.admin);
+    }
+    if (message.pagination !== undefined) {
+      PageRequest.encode(message.pagination, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryGroupAccountsByAdminRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseQueryGroupAccountsByAdminRequest,
+    } as QueryGroupAccountsByAdminRequest;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.admin = reader.string();
+          break;
+        case 2:
+          message.pagination = PageRequest.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryGroupAccountsByAdminRequest {
+    const message = {
+      ...baseQueryGroupAccountsByAdminRequest,
+    } as QueryGroupAccountsByAdminRequest;
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = String(object.admin);
+    } else {
+      message.admin = "";
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageRequest.fromJSON(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: QueryGroupAccountsByAdminRequest): unknown {
+    const obj: any = {};
+    message.admin !== undefined && (obj.admin = message.admin);
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryGroupAccountsByAdminRequest>
+  ): QueryGroupAccountsByAdminRequest {
+    const message = {
+      ...baseQueryGroupAccountsByAdminRequest,
+    } as QueryGroupAccountsByAdminRequest;
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = object.admin;
+    } else {
+      message.admin = "";
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageRequest.fromPartial(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+};
+
+const baseQueryGroupAccountsByAdminResponse: object = {};
+
+export const QueryGroupAccountsByAdminResponse = {
+  encode(
+    message: QueryGroupAccountsByAdminResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    for (const v of message.groupAccounts) {
+      GroupAccountInfo.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.pagination !== undefined) {
+      PageResponse.encode(
+        message.pagination,
+        writer.uint32(18).fork()
+      ).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryGroupAccountsByAdminResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseQueryGroupAccountsByAdminResponse,
+    } as QueryGroupAccountsByAdminResponse;
+    message.groupAccounts = [];
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.groupAccounts.push(
+            GroupAccountInfo.decode(reader, reader.uint32())
+          );
+          break;
+        case 2:
+          message.pagination = PageResponse.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryGroupAccountsByAdminResponse {
+    const message = {
+      ...baseQueryGroupAccountsByAdminResponse,
+    } as QueryGroupAccountsByAdminResponse;
+    message.groupAccounts = [];
+    if (object.groupAccounts !== undefined && object.groupAccounts !== null) {
+      for (const e of object.groupAccounts) {
+        message.groupAccounts.push(GroupAccountInfo.fromJSON(e));
+      }
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageResponse.fromJSON(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: QueryGroupAccountsByAdminResponse): unknown {
+    const obj: any = {};
+    if (message.groupAccounts) {
+      obj.groupAccounts = message.groupAccounts.map((e) =>
+        e ? GroupAccountInfo.toJSON(e) : undefined
+      );
+    } else {
+      obj.groupAccounts = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryGroupAccountsByAdminResponse>
+  ): QueryGroupAccountsByAdminResponse {
+    const message = {
+      ...baseQueryGroupAccountsByAdminResponse,
+    } as QueryGroupAccountsByAdminResponse;
+    message.groupAccounts = [];
+    if (object.groupAccounts !== undefined && object.groupAccounts !== null) {
+      for (const e of object.groupAccounts) {
+        message.groupAccounts.push(GroupAccountInfo.fromPartial(e));
+      }
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageResponse.fromPartial(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+};
+
+const baseQueryProposalRequest: object = { proposalId: Long.UZERO };
+
+export const QueryProposalRequest = {
+  encode(
+    message: QueryProposalRequest,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (!message.proposalId.isZero()) {
+      writer.uint32(8).uint64(message.proposalId);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryProposalRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseQueryProposalRequest } as QueryProposalRequest;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.proposalId = reader.uint64() as Long;
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryProposalRequest {
+    const message = { ...baseQueryProposalRequest } as QueryProposalRequest;
+    if (object.proposalId !== undefined && object.proposalId !== null) {
+      message.proposalId = Long.fromString(object.proposalId);
+    } else {
+      message.proposalId = Long.UZERO;
+    }
+    return message;
+  },
+
+  toJSON(message: QueryProposalRequest): unknown {
+    const obj: any = {};
+    message.proposalId !== undefined &&
+      (obj.proposalId = (message.proposalId || Long.UZERO).toString());
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<QueryProposalRequest>): QueryProposalRequest {
+    const message = { ...baseQueryProposalRequest } as QueryProposalRequest;
+    if (object.proposalId !== undefined && object.proposalId !== null) {
+      message.proposalId = object.proposalId as Long;
+    } else {
+      message.proposalId = Long.UZERO;
+    }
+    return message;
+  },
+};
+
+const baseQueryProposalResponse: object = {};
+
+export const QueryProposalResponse = {
+  encode(
+    message: QueryProposalResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.proposal !== undefined) {
+      Proposal.encode(message.proposal, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryProposalResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseQueryProposalResponse } as QueryProposalResponse;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.proposal = Proposal.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryProposalResponse {
+    const message = { ...baseQueryProposalResponse } as QueryProposalResponse;
+    if (object.proposal !== undefined && object.proposal !== null) {
+      message.proposal = Proposal.fromJSON(object.proposal);
+    } else {
+      message.proposal = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: QueryProposalResponse): unknown {
+    const obj: any = {};
+    message.proposal !== undefined &&
+      (obj.proposal = message.proposal
+        ? Proposal.toJSON(message.proposal)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryProposalResponse>
+  ): QueryProposalResponse {
+    const message = { ...baseQueryProposalResponse } as QueryProposalResponse;
+    if (object.proposal !== undefined && object.proposal !== null) {
+      message.proposal = Proposal.fromPartial(object.proposal);
+    } else {
+      message.proposal = undefined;
+    }
+    return message;
+  },
+};
+
+const baseQueryProposalsByGroupAccountRequest: object = { address: "" };
+
+export const QueryProposalsByGroupAccountRequest = {
+  encode(
+    message: QueryProposalsByGroupAccountRequest,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.address !== "") {
+      writer.uint32(10).string(message.address);
+    }
+    if (message.pagination !== undefined) {
+      PageRequest.encode(message.pagination, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryProposalsByGroupAccountRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseQueryProposalsByGroupAccountRequest,
+    } as QueryProposalsByGroupAccountRequest;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.address = reader.string();
+          break;
+        case 2:
+          message.pagination = PageRequest.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryProposalsByGroupAccountRequest {
+    const message = {
+      ...baseQueryProposalsByGroupAccountRequest,
+    } as QueryProposalsByGroupAccountRequest;
+    if (object.address !== undefined && object.address !== null) {
+      message.address = String(object.address);
+    } else {
+      message.address = "";
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageRequest.fromJSON(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: QueryProposalsByGroupAccountRequest): unknown {
+    const obj: any = {};
+    message.address !== undefined && (obj.address = message.address);
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryProposalsByGroupAccountRequest>
+  ): QueryProposalsByGroupAccountRequest {
+    const message = {
+      ...baseQueryProposalsByGroupAccountRequest,
+    } as QueryProposalsByGroupAccountRequest;
+    if (object.address !== undefined && object.address !== null) {
+      message.address = object.address;
+    } else {
+      message.address = "";
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageRequest.fromPartial(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+};
+
+const baseQueryProposalsByGroupAccountResponse: object = {};
+
+export const QueryProposalsByGroupAccountResponse = {
+  encode(
+    message: QueryProposalsByGroupAccountResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    for (const v of message.proposals) {
+      Proposal.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.pagination !== undefined) {
+      PageResponse.encode(
+        message.pagination,
+        writer.uint32(18).fork()
+      ).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryProposalsByGroupAccountResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseQueryProposalsByGroupAccountResponse,
+    } as QueryProposalsByGroupAccountResponse;
+    message.proposals = [];
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.proposals.push(Proposal.decode(reader, reader.uint32()));
+          break;
+        case 2:
+          message.pagination = PageResponse.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryProposalsByGroupAccountResponse {
+    const message = {
+      ...baseQueryProposalsByGroupAccountResponse,
+    } as QueryProposalsByGroupAccountResponse;
+    message.proposals = [];
+    if (object.proposals !== undefined && object.proposals !== null) {
+      for (const e of object.proposals) {
+        message.proposals.push(Proposal.fromJSON(e));
+      }
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageResponse.fromJSON(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: QueryProposalsByGroupAccountResponse): unknown {
+    const obj: any = {};
+    if (message.proposals) {
+      obj.proposals = message.proposals.map((e) =>
+        e ? Proposal.toJSON(e) : undefined
+      );
+    } else {
+      obj.proposals = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryProposalsByGroupAccountResponse>
+  ): QueryProposalsByGroupAccountResponse {
+    const message = {
+      ...baseQueryProposalsByGroupAccountResponse,
+    } as QueryProposalsByGroupAccountResponse;
+    message.proposals = [];
+    if (object.proposals !== undefined && object.proposals !== null) {
+      for (const e of object.proposals) {
+        message.proposals.push(Proposal.fromPartial(e));
+      }
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageResponse.fromPartial(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+};
+
+const baseQueryVoteByProposalVoterRequest: object = {
+  proposalId: Long.UZERO,
+  voter: "",
+};
+
+export const QueryVoteByProposalVoterRequest = {
+  encode(
+    message: QueryVoteByProposalVoterRequest,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (!message.proposalId.isZero()) {
+      writer.uint32(8).uint64(message.proposalId);
+    }
+    if (message.voter !== "") {
+      writer.uint32(18).string(message.voter);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryVoteByProposalVoterRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseQueryVoteByProposalVoterRequest,
+    } as QueryVoteByProposalVoterRequest;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.proposalId = reader.uint64() as Long;
+          break;
+        case 2:
+          message.voter = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryVoteByProposalVoterRequest {
+    const message = {
+      ...baseQueryVoteByProposalVoterRequest,
+    } as QueryVoteByProposalVoterRequest;
+    if (object.proposalId !== undefined && object.proposalId !== null) {
+      message.proposalId = Long.fromString(object.proposalId);
+    } else {
+      message.proposalId = Long.UZERO;
+    }
+    if (object.voter !== undefined && object.voter !== null) {
+      message.voter = String(object.voter);
+    } else {
+      message.voter = "";
+    }
+    return message;
+  },
+
+  toJSON(message: QueryVoteByProposalVoterRequest): unknown {
+    const obj: any = {};
+    message.proposalId !== undefined &&
+      (obj.proposalId = (message.proposalId || Long.UZERO).toString());
+    message.voter !== undefined && (obj.voter = message.voter);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryVoteByProposalVoterRequest>
+  ): QueryVoteByProposalVoterRequest {
+    const message = {
+      ...baseQueryVoteByProposalVoterRequest,
+    } as QueryVoteByProposalVoterRequest;
+    if (object.proposalId !== undefined && object.proposalId !== null) {
+      message.proposalId = object.proposalId as Long;
+    } else {
+      message.proposalId = Long.UZERO;
+    }
+    if (object.voter !== undefined && object.voter !== null) {
+      message.voter = object.voter;
+    } else {
+      message.voter = "";
+    }
+    return message;
+  },
+};
+
+const baseQueryVoteByProposalVoterResponse: object = {};
+
+export const QueryVoteByProposalVoterResponse = {
+  encode(
+    message: QueryVoteByProposalVoterResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.vote !== undefined) {
+      Vote.encode(message.vote, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryVoteByProposalVoterResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseQueryVoteByProposalVoterResponse,
+    } as QueryVoteByProposalVoterResponse;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.vote = Vote.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryVoteByProposalVoterResponse {
+    const message = {
+      ...baseQueryVoteByProposalVoterResponse,
+    } as QueryVoteByProposalVoterResponse;
+    if (object.vote !== undefined && object.vote !== null) {
+      message.vote = Vote.fromJSON(object.vote);
+    } else {
+      message.vote = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: QueryVoteByProposalVoterResponse): unknown {
+    const obj: any = {};
+    message.vote !== undefined &&
+      (obj.vote = message.vote ? Vote.toJSON(message.vote) : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryVoteByProposalVoterResponse>
+  ): QueryVoteByProposalVoterResponse {
+    const message = {
+      ...baseQueryVoteByProposalVoterResponse,
+    } as QueryVoteByProposalVoterResponse;
+    if (object.vote !== undefined && object.vote !== null) {
+      message.vote = Vote.fromPartial(object.vote);
+    } else {
+      message.vote = undefined;
+    }
+    return message;
+  },
+};
+
+const baseQueryVotesByProposalRequest: object = { proposalId: Long.UZERO };
+
+export const QueryVotesByProposalRequest = {
+  encode(
+    message: QueryVotesByProposalRequest,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (!message.proposalId.isZero()) {
+      writer.uint32(8).uint64(message.proposalId);
+    }
+    if (message.pagination !== undefined) {
+      PageRequest.encode(message.pagination, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryVotesByProposalRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseQueryVotesByProposalRequest,
+    } as QueryVotesByProposalRequest;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.proposalId = reader.uint64() as Long;
+          break;
+        case 2:
+          message.pagination = PageRequest.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryVotesByProposalRequest {
+    const message = {
+      ...baseQueryVotesByProposalRequest,
+    } as QueryVotesByProposalRequest;
+    if (object.proposalId !== undefined && object.proposalId !== null) {
+      message.proposalId = Long.fromString(object.proposalId);
+    } else {
+      message.proposalId = Long.UZERO;
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageRequest.fromJSON(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: QueryVotesByProposalRequest): unknown {
+    const obj: any = {};
+    message.proposalId !== undefined &&
+      (obj.proposalId = (message.proposalId || Long.UZERO).toString());
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryVotesByProposalRequest>
+  ): QueryVotesByProposalRequest {
+    const message = {
+      ...baseQueryVotesByProposalRequest,
+    } as QueryVotesByProposalRequest;
+    if (object.proposalId !== undefined && object.proposalId !== null) {
+      message.proposalId = object.proposalId as Long;
+    } else {
+      message.proposalId = Long.UZERO;
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageRequest.fromPartial(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+};
+
+const baseQueryVotesByProposalResponse: object = {};
+
+export const QueryVotesByProposalResponse = {
+  encode(
+    message: QueryVotesByProposalResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    for (const v of message.votes) {
+      Vote.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.pagination !== undefined) {
+      PageResponse.encode(
+        message.pagination,
+        writer.uint32(18).fork()
+      ).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryVotesByProposalResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseQueryVotesByProposalResponse,
+    } as QueryVotesByProposalResponse;
+    message.votes = [];
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.votes.push(Vote.decode(reader, reader.uint32()));
+          break;
+        case 2:
+          message.pagination = PageResponse.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryVotesByProposalResponse {
+    const message = {
+      ...baseQueryVotesByProposalResponse,
+    } as QueryVotesByProposalResponse;
+    message.votes = [];
+    if (object.votes !== undefined && object.votes !== null) {
+      for (const e of object.votes) {
+        message.votes.push(Vote.fromJSON(e));
+      }
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageResponse.fromJSON(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: QueryVotesByProposalResponse): unknown {
+    const obj: any = {};
+    if (message.votes) {
+      obj.votes = message.votes.map((e) => (e ? Vote.toJSON(e) : undefined));
+    } else {
+      obj.votes = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryVotesByProposalResponse>
+  ): QueryVotesByProposalResponse {
+    const message = {
+      ...baseQueryVotesByProposalResponse,
+    } as QueryVotesByProposalResponse;
+    message.votes = [];
+    if (object.votes !== undefined && object.votes !== null) {
+      for (const e of object.votes) {
+        message.votes.push(Vote.fromPartial(e));
+      }
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageResponse.fromPartial(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+};
+
+const baseQueryVotesByVoterRequest: object = { voter: "" };
+
+export const QueryVotesByVoterRequest = {
+  encode(
+    message: QueryVotesByVoterRequest,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.voter !== "") {
+      writer.uint32(10).string(message.voter);
+    }
+    if (message.pagination !== undefined) {
+      PageRequest.encode(message.pagination, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryVotesByVoterRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseQueryVotesByVoterRequest,
+    } as QueryVotesByVoterRequest;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.voter = reader.string();
+          break;
+        case 2:
+          message.pagination = PageRequest.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryVotesByVoterRequest {
+    const message = {
+      ...baseQueryVotesByVoterRequest,
+    } as QueryVotesByVoterRequest;
+    if (object.voter !== undefined && object.voter !== null) {
+      message.voter = String(object.voter);
+    } else {
+      message.voter = "";
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageRequest.fromJSON(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: QueryVotesByVoterRequest): unknown {
+    const obj: any = {};
+    message.voter !== undefined && (obj.voter = message.voter);
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryVotesByVoterRequest>
+  ): QueryVotesByVoterRequest {
+    const message = {
+      ...baseQueryVotesByVoterRequest,
+    } as QueryVotesByVoterRequest;
+    if (object.voter !== undefined && object.voter !== null) {
+      message.voter = object.voter;
+    } else {
+      message.voter = "";
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageRequest.fromPartial(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+};
+
+const baseQueryVotesByVoterResponse: object = {};
+
+export const QueryVotesByVoterResponse = {
+  encode(
+    message: QueryVotesByVoterResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    for (const v of message.votes) {
+      Vote.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.pagination !== undefined) {
+      PageResponse.encode(
+        message.pagination,
+        writer.uint32(18).fork()
+      ).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): QueryVotesByVoterResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseQueryVotesByVoterResponse,
+    } as QueryVotesByVoterResponse;
+    message.votes = [];
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.votes.push(Vote.decode(reader, reader.uint32()));
+          break;
+        case 2:
+          message.pagination = PageResponse.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryVotesByVoterResponse {
+    const message = {
+      ...baseQueryVotesByVoterResponse,
+    } as QueryVotesByVoterResponse;
+    message.votes = [];
+    if (object.votes !== undefined && object.votes !== null) {
+      for (const e of object.votes) {
+        message.votes.push(Vote.fromJSON(e));
+      }
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageResponse.fromJSON(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: QueryVotesByVoterResponse): unknown {
+    const obj: any = {};
+    if (message.votes) {
+      obj.votes = message.votes.map((e) => (e ? Vote.toJSON(e) : undefined));
+    } else {
+      obj.votes = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<QueryVotesByVoterResponse>
+  ): QueryVotesByVoterResponse {
+    const message = {
+      ...baseQueryVotesByVoterResponse,
+    } as QueryVotesByVoterResponse;
+    message.votes = [];
+    if (object.votes !== undefined && object.votes !== null) {
+      for (const e of object.votes) {
+        message.votes.push(Vote.fromPartial(e));
+      }
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageResponse.fromPartial(object.pagination);
+    } else {
+      message.pagination = undefined;
+    }
+    return message;
+  },
+};
+
+/** Query is the regen.group.v1alpha1 Query service. */
+export interface Query {
+  /** GroupInfo queries group info based on group id. */
+  GroupInfo(request: QueryGroupInfoRequest): Promise<QueryGroupInfoResponse>;
+  /** GroupAccountInfo queries group account info based on group account address. */
+  GroupAccountInfo(
+    request: QueryGroupAccountInfoRequest
+  ): Promise<QueryGroupAccountInfoResponse>;
+  /** GroupMembers queries members of a group */
+  GroupMembers(
+    request: QueryGroupMembersRequest
+  ): Promise<QueryGroupMembersResponse>;
+  /** GroupsByAdmin queries groups by admin address. */
+  GroupsByAdmin(
+    request: QueryGroupsByAdminRequest
+  ): Promise<QueryGroupsByAdminResponse>;
+  /** GroupAccountsByGroup queries group accounts by group id. */
+  GroupAccountsByGroup(
+    request: QueryGroupAccountsByGroupRequest
+  ): Promise<QueryGroupAccountsByGroupResponse>;
+  /** GroupsByAdmin queries group accounts by admin address. */
+  GroupAccountsByAdmin(
+    request: QueryGroupAccountsByAdminRequest
+  ): Promise<QueryGroupAccountsByAdminResponse>;
+  /** Proposal queries a proposal based on proposal id. */
+  Proposal(request: QueryProposalRequest): Promise<QueryProposalResponse>;
+  /** ProposalsByGroupAccount queries proposals based on group account address. */
+  ProposalsByGroupAccount(
+    request: QueryProposalsByGroupAccountRequest
+  ): Promise<QueryProposalsByGroupAccountResponse>;
+  /** VoteByProposalVoter queries a vote by proposal id and voter. */
+  VoteByProposalVoter(
+    request: QueryVoteByProposalVoterRequest
+  ): Promise<QueryVoteByProposalVoterResponse>;
+  /** VotesByProposal queries a vote by proposal. */
+  VotesByProposal(
+    request: QueryVotesByProposalRequest
+  ): Promise<QueryVotesByProposalResponse>;
+  /** VotesByVoter queries a vote by voter. */
+  VotesByVoter(
+    request: QueryVotesByVoterRequest
+  ): Promise<QueryVotesByVoterResponse>;
+}
+
+export class QueryClientImpl implements Query {
+  private readonly rpc: Rpc;
+  constructor(rpc: Rpc) {
+    this.rpc = rpc;
+    this.GroupInfo = this.GroupInfo.bind(this);
+    this.GroupAccountInfo = this.GroupAccountInfo.bind(this);
+    this.GroupMembers = this.GroupMembers.bind(this);
+    this.GroupsByAdmin = this.GroupsByAdmin.bind(this);
+    this.GroupAccountsByGroup = this.GroupAccountsByGroup.bind(this);
+    this.GroupAccountsByAdmin = this.GroupAccountsByAdmin.bind(this);
+    this.Proposal = this.Proposal.bind(this);
+    this.ProposalsByGroupAccount = this.ProposalsByGroupAccount.bind(this);
+    this.VoteByProposalVoter = this.VoteByProposalVoter.bind(this);
+    this.VotesByProposal = this.VotesByProposal.bind(this);
+    this.VotesByVoter = this.VotesByVoter.bind(this);
+  }
+  GroupInfo(request: QueryGroupInfoRequest): Promise<QueryGroupInfoResponse> {
+    const data = QueryGroupInfoRequest.encode(request).finish();
+    const promise = this.rpc.request(
+      "regen.group.v1alpha1.Query",
+      "GroupInfo",
+      data
+    );
+    return promise.then((data) =>
+      QueryGroupInfoResponse.decode(new _m0.Reader(data))
+    );
+  }
+
+  GroupAccountInfo(
+    request: QueryGroupAccountInfoRequest
+  ): Promise<QueryGroupAccountInfoResponse> {
+    const data = QueryGroupAccountInfoRequest.encode(request).finish();
+    const promise = this.rpc.request(
+      "regen.group.v1alpha1.Query",
+      "GroupAccountInfo",
+      data
+    );
+    return promise.then((data) =>
+      QueryGroupAccountInfoResponse.decode(new _m0.Reader(data))
+    );
+  }
+
+  GroupMembers(
+    request: QueryGroupMembersRequest
+  ): Promise<QueryGroupMembersResponse> {
+    const data = QueryGroupMembersRequest.encode(request).finish();
+    const promise = this.rpc.request(
+      "regen.group.v1alpha1.Query",
+      "GroupMembers",
+      data
+    );
+    return promise.then((data) =>
+      QueryGroupMembersResponse.decode(new _m0.Reader(data))
+    );
+  }
+
+  GroupsByAdmin(
+    request: QueryGroupsByAdminRequest
+  ): Promise<QueryGroupsByAdminResponse> {
+    const data = QueryGroupsByAdminRequest.encode(request).finish();
+    const promise = this.rpc.request(
+      "regen.group.v1alpha1.Query",
+      "GroupsByAdmin",
+      data
+    );
+    return promise.then((data) =>
+      QueryGroupsByAdminResponse.decode(new _m0.Reader(data))
+    );
+  }
+
+  GroupAccountsByGroup(
+    request: QueryGroupAccountsByGroupRequest
+  ): Promise<QueryGroupAccountsByGroupResponse> {
+    const data = QueryGroupAccountsByGroupRequest.encode(request).finish();
+    const promise = this.rpc.request(
+      "regen.group.v1alpha1.Query",
+      "GroupAccountsByGroup",
+      data
+    );
+    return promise.then((data) =>
+      QueryGroupAccountsByGroupResponse.decode(new _m0.Reader(data))
+    );
+  }
+
+  GroupAccountsByAdmin(
+    request: QueryGroupAccountsByAdminRequest
+  ): Promise<QueryGroupAccountsByAdminResponse> {
+    const data = QueryGroupAccountsByAdminRequest.encode(request).finish();
+    const promise = this.rpc.request(
+      "regen.group.v1alpha1.Query",
+      "GroupAccountsByAdmin",
+      data
+    );
+    return promise.then((data) =>
+      QueryGroupAccountsByAdminResponse.decode(new _m0.Reader(data))
+    );
+  }
+
+  Proposal(request: QueryProposalRequest): Promise<QueryProposalResponse> {
+    const data = QueryProposalRequest.encode(request).finish();
+    const promise = this.rpc.request(
+      "regen.group.v1alpha1.Query",
+      "Proposal",
+      data
+    );
+    return promise.then((data) =>
+      QueryProposalResponse.decode(new _m0.Reader(data))
+    );
+  }
+
+  ProposalsByGroupAccount(
+    request: QueryProposalsByGroupAccountRequest
+  ): Promise<QueryProposalsByGroupAccountResponse> {
+    const data = QueryProposalsByGroupAccountRequest.encode(request).finish();
+    const promise = this.rpc.request(
+      "regen.group.v1alpha1.Query",
+      "ProposalsByGroupAccount",
+      data
+    );
+    return promise.then((data) =>
+      QueryProposalsByGroupAccountResponse.decode(new _m0.Reader(data))
+    );
+  }
+
+  VoteByProposalVoter(
+    request: QueryVoteByProposalVoterRequest
+  ): Promise<QueryVoteByProposalVoterResponse> {
+    const data = QueryVoteByProposalVoterRequest.encode(request).finish();
+    const promise = this.rpc.request(
+      "regen.group.v1alpha1.Query",
+      "VoteByProposalVoter",
+      data
+    );
+    return promise.then((data) =>
+      QueryVoteByProposalVoterResponse.decode(new _m0.Reader(data))
+    );
+  }
+
+  VotesByProposal(
+    request: QueryVotesByProposalRequest
+  ): Promise<QueryVotesByProposalResponse> {
+    const data = QueryVotesByProposalRequest.encode(request).finish();
+    const promise = this.rpc.request(
+      "regen.group.v1alpha1.Query",
+      "VotesByProposal",
+      data
+    );
+    return promise.then((data) =>
+      QueryVotesByProposalResponse.decode(new _m0.Reader(data))
+    );
+  }
+
+  VotesByVoter(
+    request: QueryVotesByVoterRequest
+  ): Promise<QueryVotesByVoterResponse> {
+    const data = QueryVotesByVoterRequest.encode(request).finish();
+    const promise = this.rpc.request(
+      "regen.group.v1alpha1.Query",
+      "VotesByVoter",
+      data
+    );
+    return promise.then((data) =>
+      QueryVotesByVoterResponse.decode(new _m0.Reader(data))
+    );
+  }
+}
+
+interface Rpc {
+  request(
+    service: string,
+    method: string,
+    data: Uint8Array
+  ): Promise<Uint8Array>;
+}
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined
+  | Long;
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : T extends {}
+  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}

--- a/src/regen/group/v1alpha1/tx.ts
+++ b/src/regen/group/v1alpha1/tx.ts
@@ -1,0 +1,2294 @@
+/* eslint-disable */
+import Long from "long";
+import _m0 from "protobufjs/minimal";
+import { Any } from "../../../google/protobuf/any";
+import {
+  Choice,
+  Member,
+  choiceFromJSON,
+  choiceToJSON,
+} from "../../../regen/group/v1alpha1/types";
+
+export const protobufPackage = "regen.group.v1alpha1";
+
+/** Exec defines modes of execution of a proposal on creation or on new vote. */
+export enum Exec {
+  /**
+   * EXEC_UNSPECIFIED - An empty value means that there should be a separate
+   * MsgExec request for the proposal to execute.
+   */
+  EXEC_UNSPECIFIED = 0,
+  /**
+   * EXEC_TRY - Try to execute the proposal immediately.
+   * If the proposal is not allowed per the DecisionPolicy,
+   * the proposal will still be open and could
+   * be executed at a later point.
+   */
+  EXEC_TRY = 1,
+  UNRECOGNIZED = -1,
+}
+
+export function execFromJSON(object: any): Exec {
+  switch (object) {
+    case 0:
+    case "EXEC_UNSPECIFIED":
+      return Exec.EXEC_UNSPECIFIED;
+    case 1:
+    case "EXEC_TRY":
+      return Exec.EXEC_TRY;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return Exec.UNRECOGNIZED;
+  }
+}
+
+export function execToJSON(object: Exec): string {
+  switch (object) {
+    case Exec.EXEC_UNSPECIFIED:
+      return "EXEC_UNSPECIFIED";
+    case Exec.EXEC_TRY:
+      return "EXEC_TRY";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+/** MsgCreateGroup is the Msg/CreateGroup request type. */
+export interface MsgCreateGroup {
+  /** admin is the account address of the group admin. */
+  admin: string;
+  /** members defines the group members. */
+  members: Member[];
+  /** metadata is any arbitrary metadata to attached to the group. */
+  metadata: Uint8Array;
+}
+
+/** MsgCreateGroupResponse is the Msg/CreateGroup response type. */
+export interface MsgCreateGroupResponse {
+  /** group_id is the unique ID of the newly created group. */
+  groupId: Long;
+}
+
+/** MsgUpdateGroupMembers is the Msg/UpdateGroupMembers request type. */
+export interface MsgUpdateGroupMembers {
+  /** admin is the account address of the group admin. */
+  admin: string;
+  /** group_id is the unique ID of the group. */
+  groupId: Long;
+  /**
+   * member_updates is the list of members to update,
+   * set weight to 0 to remove a member.
+   */
+  memberUpdates: Member[];
+}
+
+/** MsgUpdateGroupMembersResponse is the Msg/UpdateGroupMembers response type. */
+export interface MsgUpdateGroupMembersResponse {}
+
+/** MsgUpdateGroupAdmin is the Msg/UpdateGroupAdmin request type. */
+export interface MsgUpdateGroupAdmin {
+  /** admin is the current account address of the group admin. */
+  admin: string;
+  /** group_id is the unique ID of the group. */
+  groupId: Long;
+  /** new_admin is the group new admin account address. */
+  newAdmin: string;
+}
+
+/** MsgUpdateGroupAdminResponse is the Msg/UpdateGroupAdmin response type. */
+export interface MsgUpdateGroupAdminResponse {}
+
+/** MsgUpdateGroupMetadata is the Msg/UpdateGroupMetadata request type. */
+export interface MsgUpdateGroupMetadata {
+  /** admin is the account address of the group admin. */
+  admin: string;
+  /** group_id is the unique ID of the group. */
+  groupId: Long;
+  /** metadata is the updated group's metadata. */
+  metadata: Uint8Array;
+}
+
+/** MsgUpdateGroupMetadataResponse is the Msg/UpdateGroupMetadata response type. */
+export interface MsgUpdateGroupMetadataResponse {}
+
+/** MsgCreateGroupAccount is the Msg/CreateGroupAccount request type. */
+export interface MsgCreateGroupAccount {
+  /** admin is the account address of the group admin. */
+  admin: string;
+  /** group_id is the unique ID of the group. */
+  groupId: Long;
+  /** metadata is any arbitrary metadata to attached to the group account. */
+  metadata: Uint8Array;
+  /** decision_policy specifies the group account's decision policy. */
+  decisionPolicy?: Any;
+}
+
+/** MsgCreateGroupAccountResponse is the Msg/CreateGroupAccount response type. */
+export interface MsgCreateGroupAccountResponse {
+  /** address is the account address of the newly created group account. */
+  address: string;
+}
+
+/** MsgUpdateGroupAccountAdmin is the Msg/UpdateGroupAccountAdmin request type. */
+export interface MsgUpdateGroupAccountAdmin {
+  /** admin is the account address of the group admin. */
+  admin: string;
+  /** address is the group account address. */
+  address: string;
+  /** new_admin is the new group account admin. */
+  newAdmin: string;
+}
+
+/** MsgUpdateGroupAccountAdminResponse is the Msg/UpdateGroupAccountAdmin response type. */
+export interface MsgUpdateGroupAccountAdminResponse {}
+
+/** MsgUpdateGroupAccountDecisionPolicy is the Msg/UpdateGroupAccountDecisionPolicy request type. */
+export interface MsgUpdateGroupAccountDecisionPolicy {
+  /** admin is the account address of the group admin. */
+  admin: string;
+  /** address is the group account address. */
+  address: string;
+  /** decision_policy is the updated group account decision policy. */
+  decisionPolicy?: Any;
+}
+
+/** MsgUpdateGroupAccountDecisionPolicyResponse is the Msg/UpdateGroupAccountDecisionPolicy response type. */
+export interface MsgUpdateGroupAccountDecisionPolicyResponse {}
+
+/** MsgUpdateGroupAccountMetadata is the Msg/UpdateGroupAccountMetadata request type. */
+export interface MsgUpdateGroupAccountMetadata {
+  /** admin is the account address of the group admin. */
+  admin: string;
+  /** address is the group account address. */
+  address: string;
+  /** metadata is the updated group account metadata. */
+  metadata: Uint8Array;
+}
+
+/** MsgUpdateGroupAccountMetadataResponse is the Msg/UpdateGroupAccountMetadata response type. */
+export interface MsgUpdateGroupAccountMetadataResponse {}
+
+/** MsgCreateProposal is the Msg/CreateProposal request type. */
+export interface MsgCreateProposal {
+  /** address is the group account address. */
+  address: string;
+  /**
+   * proposers are the account addresses of the proposers.
+   * Proposers signatures will be counted as yes votes.
+   */
+  proposers: string[];
+  /** metadata is any arbitrary metadata to attached to the proposal. */
+  metadata: Uint8Array;
+  /** msgs is a list of Msgs that will be executed if the proposal passes. */
+  msgs: Any[];
+  /**
+   * exec defines the mode of execution of the proposal,
+   * whether it should be executed immediately on creation or not.
+   * If so, proposers signatures are considered as Yes votes.
+   */
+  exec: Exec;
+}
+
+/** MsgCreateProposalResponse is the Msg/CreateProposal response type. */
+export interface MsgCreateProposalResponse {
+  /** proposal is the unique ID of the proposal. */
+  proposalId: Long;
+}
+
+/** MsgVote is the Msg/Vote request type. */
+export interface MsgVote {
+  /** proposal is the unique ID of the proposal. */
+  proposalId: Long;
+  /** voter is the voter account address. */
+  voter: string;
+  /** choice is the voter's choice on the proposal. */
+  choice: Choice;
+  /** metadata is any arbitrary metadata to attached to the vote. */
+  metadata: Uint8Array;
+  /**
+   * exec defines whether the proposal should be executed
+   * immediately after voting or not.
+   */
+  exec: Exec;
+}
+
+/** MsgVoteResponse is the Msg/Vote response type. */
+export interface MsgVoteResponse {}
+
+/** MsgExec is the Msg/Exec request type. */
+export interface MsgExec {
+  /** proposal is the unique ID of the proposal. */
+  proposalId: Long;
+  /** signer is the account address used to execute the proposal. */
+  signer: string;
+}
+
+/** MsgExecResponse is the Msg/Exec request type. */
+export interface MsgExecResponse {}
+
+const baseMsgCreateGroup: object = { admin: "" };
+
+export const MsgCreateGroup = {
+  encode(
+    message: MsgCreateGroup,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.admin !== "") {
+      writer.uint32(10).string(message.admin);
+    }
+    for (const v of message.members) {
+      Member.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    if (message.metadata.length !== 0) {
+      writer.uint32(26).bytes(message.metadata);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgCreateGroup {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseMsgCreateGroup } as MsgCreateGroup;
+    message.members = [];
+    message.metadata = new Uint8Array();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.admin = reader.string();
+          break;
+        case 2:
+          message.members.push(Member.decode(reader, reader.uint32()));
+          break;
+        case 3:
+          message.metadata = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgCreateGroup {
+    const message = { ...baseMsgCreateGroup } as MsgCreateGroup;
+    message.members = [];
+    message.metadata = new Uint8Array();
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = String(object.admin);
+    } else {
+      message.admin = "";
+    }
+    if (object.members !== undefined && object.members !== null) {
+      for (const e of object.members) {
+        message.members.push(Member.fromJSON(e));
+      }
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = bytesFromBase64(object.metadata);
+    }
+    return message;
+  },
+
+  toJSON(message: MsgCreateGroup): unknown {
+    const obj: any = {};
+    message.admin !== undefined && (obj.admin = message.admin);
+    if (message.members) {
+      obj.members = message.members.map((e) =>
+        e ? Member.toJSON(e) : undefined
+      );
+    } else {
+      obj.members = [];
+    }
+    message.metadata !== undefined &&
+      (obj.metadata = base64FromBytes(
+        message.metadata !== undefined ? message.metadata : new Uint8Array()
+      ));
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<MsgCreateGroup>): MsgCreateGroup {
+    const message = { ...baseMsgCreateGroup } as MsgCreateGroup;
+    message.members = [];
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = object.admin;
+    } else {
+      message.admin = "";
+    }
+    if (object.members !== undefined && object.members !== null) {
+      for (const e of object.members) {
+        message.members.push(Member.fromPartial(e));
+      }
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = object.metadata;
+    } else {
+      message.metadata = new Uint8Array();
+    }
+    return message;
+  },
+};
+
+const baseMsgCreateGroupResponse: object = { groupId: Long.UZERO };
+
+export const MsgCreateGroupResponse = {
+  encode(
+    message: MsgCreateGroupResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (!message.groupId.isZero()) {
+      writer.uint32(8).uint64(message.groupId);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): MsgCreateGroupResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseMsgCreateGroupResponse } as MsgCreateGroupResponse;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.groupId = reader.uint64() as Long;
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgCreateGroupResponse {
+    const message = { ...baseMsgCreateGroupResponse } as MsgCreateGroupResponse;
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = Long.fromString(object.groupId);
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    return message;
+  },
+
+  toJSON(message: MsgCreateGroupResponse): unknown {
+    const obj: any = {};
+    message.groupId !== undefined &&
+      (obj.groupId = (message.groupId || Long.UZERO).toString());
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<MsgCreateGroupResponse>
+  ): MsgCreateGroupResponse {
+    const message = { ...baseMsgCreateGroupResponse } as MsgCreateGroupResponse;
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = object.groupId as Long;
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    return message;
+  },
+};
+
+const baseMsgUpdateGroupMembers: object = { admin: "", groupId: Long.UZERO };
+
+export const MsgUpdateGroupMembers = {
+  encode(
+    message: MsgUpdateGroupMembers,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.admin !== "") {
+      writer.uint32(10).string(message.admin);
+    }
+    if (!message.groupId.isZero()) {
+      writer.uint32(16).uint64(message.groupId);
+    }
+    for (const v of message.memberUpdates) {
+      Member.encode(v!, writer.uint32(26).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): MsgUpdateGroupMembers {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseMsgUpdateGroupMembers } as MsgUpdateGroupMembers;
+    message.memberUpdates = [];
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.admin = reader.string();
+          break;
+        case 2:
+          message.groupId = reader.uint64() as Long;
+          break;
+        case 3:
+          message.memberUpdates.push(Member.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgUpdateGroupMembers {
+    const message = { ...baseMsgUpdateGroupMembers } as MsgUpdateGroupMembers;
+    message.memberUpdates = [];
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = String(object.admin);
+    } else {
+      message.admin = "";
+    }
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = Long.fromString(object.groupId);
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    if (object.memberUpdates !== undefined && object.memberUpdates !== null) {
+      for (const e of object.memberUpdates) {
+        message.memberUpdates.push(Member.fromJSON(e));
+      }
+    }
+    return message;
+  },
+
+  toJSON(message: MsgUpdateGroupMembers): unknown {
+    const obj: any = {};
+    message.admin !== undefined && (obj.admin = message.admin);
+    message.groupId !== undefined &&
+      (obj.groupId = (message.groupId || Long.UZERO).toString());
+    if (message.memberUpdates) {
+      obj.memberUpdates = message.memberUpdates.map((e) =>
+        e ? Member.toJSON(e) : undefined
+      );
+    } else {
+      obj.memberUpdates = [];
+    }
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<MsgUpdateGroupMembers>
+  ): MsgUpdateGroupMembers {
+    const message = { ...baseMsgUpdateGroupMembers } as MsgUpdateGroupMembers;
+    message.memberUpdates = [];
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = object.admin;
+    } else {
+      message.admin = "";
+    }
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = object.groupId as Long;
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    if (object.memberUpdates !== undefined && object.memberUpdates !== null) {
+      for (const e of object.memberUpdates) {
+        message.memberUpdates.push(Member.fromPartial(e));
+      }
+    }
+    return message;
+  },
+};
+
+const baseMsgUpdateGroupMembersResponse: object = {};
+
+export const MsgUpdateGroupMembersResponse = {
+  encode(
+    _: MsgUpdateGroupMembersResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): MsgUpdateGroupMembersResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseMsgUpdateGroupMembersResponse,
+    } as MsgUpdateGroupMembersResponse;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgUpdateGroupMembersResponse {
+    const message = {
+      ...baseMsgUpdateGroupMembersResponse,
+    } as MsgUpdateGroupMembersResponse;
+    return message;
+  },
+
+  toJSON(_: MsgUpdateGroupMembersResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial(
+    _: DeepPartial<MsgUpdateGroupMembersResponse>
+  ): MsgUpdateGroupMembersResponse {
+    const message = {
+      ...baseMsgUpdateGroupMembersResponse,
+    } as MsgUpdateGroupMembersResponse;
+    return message;
+  },
+};
+
+const baseMsgUpdateGroupAdmin: object = {
+  admin: "",
+  groupId: Long.UZERO,
+  newAdmin: "",
+};
+
+export const MsgUpdateGroupAdmin = {
+  encode(
+    message: MsgUpdateGroupAdmin,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.admin !== "") {
+      writer.uint32(10).string(message.admin);
+    }
+    if (!message.groupId.isZero()) {
+      writer.uint32(16).uint64(message.groupId);
+    }
+    if (message.newAdmin !== "") {
+      writer.uint32(26).string(message.newAdmin);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgUpdateGroupAdmin {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseMsgUpdateGroupAdmin } as MsgUpdateGroupAdmin;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.admin = reader.string();
+          break;
+        case 2:
+          message.groupId = reader.uint64() as Long;
+          break;
+        case 3:
+          message.newAdmin = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgUpdateGroupAdmin {
+    const message = { ...baseMsgUpdateGroupAdmin } as MsgUpdateGroupAdmin;
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = String(object.admin);
+    } else {
+      message.admin = "";
+    }
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = Long.fromString(object.groupId);
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    if (object.newAdmin !== undefined && object.newAdmin !== null) {
+      message.newAdmin = String(object.newAdmin);
+    } else {
+      message.newAdmin = "";
+    }
+    return message;
+  },
+
+  toJSON(message: MsgUpdateGroupAdmin): unknown {
+    const obj: any = {};
+    message.admin !== undefined && (obj.admin = message.admin);
+    message.groupId !== undefined &&
+      (obj.groupId = (message.groupId || Long.UZERO).toString());
+    message.newAdmin !== undefined && (obj.newAdmin = message.newAdmin);
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<MsgUpdateGroupAdmin>): MsgUpdateGroupAdmin {
+    const message = { ...baseMsgUpdateGroupAdmin } as MsgUpdateGroupAdmin;
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = object.admin;
+    } else {
+      message.admin = "";
+    }
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = object.groupId as Long;
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    if (object.newAdmin !== undefined && object.newAdmin !== null) {
+      message.newAdmin = object.newAdmin;
+    } else {
+      message.newAdmin = "";
+    }
+    return message;
+  },
+};
+
+const baseMsgUpdateGroupAdminResponse: object = {};
+
+export const MsgUpdateGroupAdminResponse = {
+  encode(
+    _: MsgUpdateGroupAdminResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): MsgUpdateGroupAdminResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseMsgUpdateGroupAdminResponse,
+    } as MsgUpdateGroupAdminResponse;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgUpdateGroupAdminResponse {
+    const message = {
+      ...baseMsgUpdateGroupAdminResponse,
+    } as MsgUpdateGroupAdminResponse;
+    return message;
+  },
+
+  toJSON(_: MsgUpdateGroupAdminResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial(
+    _: DeepPartial<MsgUpdateGroupAdminResponse>
+  ): MsgUpdateGroupAdminResponse {
+    const message = {
+      ...baseMsgUpdateGroupAdminResponse,
+    } as MsgUpdateGroupAdminResponse;
+    return message;
+  },
+};
+
+const baseMsgUpdateGroupMetadata: object = { admin: "", groupId: Long.UZERO };
+
+export const MsgUpdateGroupMetadata = {
+  encode(
+    message: MsgUpdateGroupMetadata,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.admin !== "") {
+      writer.uint32(10).string(message.admin);
+    }
+    if (!message.groupId.isZero()) {
+      writer.uint32(16).uint64(message.groupId);
+    }
+    if (message.metadata.length !== 0) {
+      writer.uint32(26).bytes(message.metadata);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): MsgUpdateGroupMetadata {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseMsgUpdateGroupMetadata } as MsgUpdateGroupMetadata;
+    message.metadata = new Uint8Array();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.admin = reader.string();
+          break;
+        case 2:
+          message.groupId = reader.uint64() as Long;
+          break;
+        case 3:
+          message.metadata = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgUpdateGroupMetadata {
+    const message = { ...baseMsgUpdateGroupMetadata } as MsgUpdateGroupMetadata;
+    message.metadata = new Uint8Array();
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = String(object.admin);
+    } else {
+      message.admin = "";
+    }
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = Long.fromString(object.groupId);
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = bytesFromBase64(object.metadata);
+    }
+    return message;
+  },
+
+  toJSON(message: MsgUpdateGroupMetadata): unknown {
+    const obj: any = {};
+    message.admin !== undefined && (obj.admin = message.admin);
+    message.groupId !== undefined &&
+      (obj.groupId = (message.groupId || Long.UZERO).toString());
+    message.metadata !== undefined &&
+      (obj.metadata = base64FromBytes(
+        message.metadata !== undefined ? message.metadata : new Uint8Array()
+      ));
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<MsgUpdateGroupMetadata>
+  ): MsgUpdateGroupMetadata {
+    const message = { ...baseMsgUpdateGroupMetadata } as MsgUpdateGroupMetadata;
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = object.admin;
+    } else {
+      message.admin = "";
+    }
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = object.groupId as Long;
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = object.metadata;
+    } else {
+      message.metadata = new Uint8Array();
+    }
+    return message;
+  },
+};
+
+const baseMsgUpdateGroupMetadataResponse: object = {};
+
+export const MsgUpdateGroupMetadataResponse = {
+  encode(
+    _: MsgUpdateGroupMetadataResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): MsgUpdateGroupMetadataResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseMsgUpdateGroupMetadataResponse,
+    } as MsgUpdateGroupMetadataResponse;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgUpdateGroupMetadataResponse {
+    const message = {
+      ...baseMsgUpdateGroupMetadataResponse,
+    } as MsgUpdateGroupMetadataResponse;
+    return message;
+  },
+
+  toJSON(_: MsgUpdateGroupMetadataResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial(
+    _: DeepPartial<MsgUpdateGroupMetadataResponse>
+  ): MsgUpdateGroupMetadataResponse {
+    const message = {
+      ...baseMsgUpdateGroupMetadataResponse,
+    } as MsgUpdateGroupMetadataResponse;
+    return message;
+  },
+};
+
+const baseMsgCreateGroupAccount: object = { admin: "", groupId: Long.UZERO };
+
+export const MsgCreateGroupAccount = {
+  encode(
+    message: MsgCreateGroupAccount,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.admin !== "") {
+      writer.uint32(10).string(message.admin);
+    }
+    if (!message.groupId.isZero()) {
+      writer.uint32(16).uint64(message.groupId);
+    }
+    if (message.metadata.length !== 0) {
+      writer.uint32(26).bytes(message.metadata);
+    }
+    if (message.decisionPolicy !== undefined) {
+      Any.encode(message.decisionPolicy, writer.uint32(34).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): MsgCreateGroupAccount {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseMsgCreateGroupAccount } as MsgCreateGroupAccount;
+    message.metadata = new Uint8Array();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.admin = reader.string();
+          break;
+        case 2:
+          message.groupId = reader.uint64() as Long;
+          break;
+        case 3:
+          message.metadata = reader.bytes();
+          break;
+        case 4:
+          message.decisionPolicy = Any.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgCreateGroupAccount {
+    const message = { ...baseMsgCreateGroupAccount } as MsgCreateGroupAccount;
+    message.metadata = new Uint8Array();
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = String(object.admin);
+    } else {
+      message.admin = "";
+    }
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = Long.fromString(object.groupId);
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = bytesFromBase64(object.metadata);
+    }
+    if (object.decisionPolicy !== undefined && object.decisionPolicy !== null) {
+      message.decisionPolicy = Any.fromJSON(object.decisionPolicy);
+    } else {
+      message.decisionPolicy = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: MsgCreateGroupAccount): unknown {
+    const obj: any = {};
+    message.admin !== undefined && (obj.admin = message.admin);
+    message.groupId !== undefined &&
+      (obj.groupId = (message.groupId || Long.UZERO).toString());
+    message.metadata !== undefined &&
+      (obj.metadata = base64FromBytes(
+        message.metadata !== undefined ? message.metadata : new Uint8Array()
+      ));
+    message.decisionPolicy !== undefined &&
+      (obj.decisionPolicy = message.decisionPolicy
+        ? Any.toJSON(message.decisionPolicy)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<MsgCreateGroupAccount>
+  ): MsgCreateGroupAccount {
+    const message = { ...baseMsgCreateGroupAccount } as MsgCreateGroupAccount;
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = object.admin;
+    } else {
+      message.admin = "";
+    }
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = object.groupId as Long;
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = object.metadata;
+    } else {
+      message.metadata = new Uint8Array();
+    }
+    if (object.decisionPolicy !== undefined && object.decisionPolicy !== null) {
+      message.decisionPolicy = Any.fromPartial(object.decisionPolicy);
+    } else {
+      message.decisionPolicy = undefined;
+    }
+    return message;
+  },
+};
+
+const baseMsgCreateGroupAccountResponse: object = { address: "" };
+
+export const MsgCreateGroupAccountResponse = {
+  encode(
+    message: MsgCreateGroupAccountResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.address !== "") {
+      writer.uint32(10).string(message.address);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): MsgCreateGroupAccountResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseMsgCreateGroupAccountResponse,
+    } as MsgCreateGroupAccountResponse;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.address = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgCreateGroupAccountResponse {
+    const message = {
+      ...baseMsgCreateGroupAccountResponse,
+    } as MsgCreateGroupAccountResponse;
+    if (object.address !== undefined && object.address !== null) {
+      message.address = String(object.address);
+    } else {
+      message.address = "";
+    }
+    return message;
+  },
+
+  toJSON(message: MsgCreateGroupAccountResponse): unknown {
+    const obj: any = {};
+    message.address !== undefined && (obj.address = message.address);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<MsgCreateGroupAccountResponse>
+  ): MsgCreateGroupAccountResponse {
+    const message = {
+      ...baseMsgCreateGroupAccountResponse,
+    } as MsgCreateGroupAccountResponse;
+    if (object.address !== undefined && object.address !== null) {
+      message.address = object.address;
+    } else {
+      message.address = "";
+    }
+    return message;
+  },
+};
+
+const baseMsgUpdateGroupAccountAdmin: object = {
+  admin: "",
+  address: "",
+  newAdmin: "",
+};
+
+export const MsgUpdateGroupAccountAdmin = {
+  encode(
+    message: MsgUpdateGroupAccountAdmin,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.admin !== "") {
+      writer.uint32(10).string(message.admin);
+    }
+    if (message.address !== "") {
+      writer.uint32(18).string(message.address);
+    }
+    if (message.newAdmin !== "") {
+      writer.uint32(26).string(message.newAdmin);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): MsgUpdateGroupAccountAdmin {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseMsgUpdateGroupAccountAdmin,
+    } as MsgUpdateGroupAccountAdmin;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.admin = reader.string();
+          break;
+        case 2:
+          message.address = reader.string();
+          break;
+        case 3:
+          message.newAdmin = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgUpdateGroupAccountAdmin {
+    const message = {
+      ...baseMsgUpdateGroupAccountAdmin,
+    } as MsgUpdateGroupAccountAdmin;
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = String(object.admin);
+    } else {
+      message.admin = "";
+    }
+    if (object.address !== undefined && object.address !== null) {
+      message.address = String(object.address);
+    } else {
+      message.address = "";
+    }
+    if (object.newAdmin !== undefined && object.newAdmin !== null) {
+      message.newAdmin = String(object.newAdmin);
+    } else {
+      message.newAdmin = "";
+    }
+    return message;
+  },
+
+  toJSON(message: MsgUpdateGroupAccountAdmin): unknown {
+    const obj: any = {};
+    message.admin !== undefined && (obj.admin = message.admin);
+    message.address !== undefined && (obj.address = message.address);
+    message.newAdmin !== undefined && (obj.newAdmin = message.newAdmin);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<MsgUpdateGroupAccountAdmin>
+  ): MsgUpdateGroupAccountAdmin {
+    const message = {
+      ...baseMsgUpdateGroupAccountAdmin,
+    } as MsgUpdateGroupAccountAdmin;
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = object.admin;
+    } else {
+      message.admin = "";
+    }
+    if (object.address !== undefined && object.address !== null) {
+      message.address = object.address;
+    } else {
+      message.address = "";
+    }
+    if (object.newAdmin !== undefined && object.newAdmin !== null) {
+      message.newAdmin = object.newAdmin;
+    } else {
+      message.newAdmin = "";
+    }
+    return message;
+  },
+};
+
+const baseMsgUpdateGroupAccountAdminResponse: object = {};
+
+export const MsgUpdateGroupAccountAdminResponse = {
+  encode(
+    _: MsgUpdateGroupAccountAdminResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): MsgUpdateGroupAccountAdminResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseMsgUpdateGroupAccountAdminResponse,
+    } as MsgUpdateGroupAccountAdminResponse;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgUpdateGroupAccountAdminResponse {
+    const message = {
+      ...baseMsgUpdateGroupAccountAdminResponse,
+    } as MsgUpdateGroupAccountAdminResponse;
+    return message;
+  },
+
+  toJSON(_: MsgUpdateGroupAccountAdminResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial(
+    _: DeepPartial<MsgUpdateGroupAccountAdminResponse>
+  ): MsgUpdateGroupAccountAdminResponse {
+    const message = {
+      ...baseMsgUpdateGroupAccountAdminResponse,
+    } as MsgUpdateGroupAccountAdminResponse;
+    return message;
+  },
+};
+
+const baseMsgUpdateGroupAccountDecisionPolicy: object = {
+  admin: "",
+  address: "",
+};
+
+export const MsgUpdateGroupAccountDecisionPolicy = {
+  encode(
+    message: MsgUpdateGroupAccountDecisionPolicy,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.admin !== "") {
+      writer.uint32(10).string(message.admin);
+    }
+    if (message.address !== "") {
+      writer.uint32(18).string(message.address);
+    }
+    if (message.decisionPolicy !== undefined) {
+      Any.encode(message.decisionPolicy, writer.uint32(26).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): MsgUpdateGroupAccountDecisionPolicy {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseMsgUpdateGroupAccountDecisionPolicy,
+    } as MsgUpdateGroupAccountDecisionPolicy;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.admin = reader.string();
+          break;
+        case 2:
+          message.address = reader.string();
+          break;
+        case 3:
+          message.decisionPolicy = Any.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgUpdateGroupAccountDecisionPolicy {
+    const message = {
+      ...baseMsgUpdateGroupAccountDecisionPolicy,
+    } as MsgUpdateGroupAccountDecisionPolicy;
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = String(object.admin);
+    } else {
+      message.admin = "";
+    }
+    if (object.address !== undefined && object.address !== null) {
+      message.address = String(object.address);
+    } else {
+      message.address = "";
+    }
+    if (object.decisionPolicy !== undefined && object.decisionPolicy !== null) {
+      message.decisionPolicy = Any.fromJSON(object.decisionPolicy);
+    } else {
+      message.decisionPolicy = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: MsgUpdateGroupAccountDecisionPolicy): unknown {
+    const obj: any = {};
+    message.admin !== undefined && (obj.admin = message.admin);
+    message.address !== undefined && (obj.address = message.address);
+    message.decisionPolicy !== undefined &&
+      (obj.decisionPolicy = message.decisionPolicy
+        ? Any.toJSON(message.decisionPolicy)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<MsgUpdateGroupAccountDecisionPolicy>
+  ): MsgUpdateGroupAccountDecisionPolicy {
+    const message = {
+      ...baseMsgUpdateGroupAccountDecisionPolicy,
+    } as MsgUpdateGroupAccountDecisionPolicy;
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = object.admin;
+    } else {
+      message.admin = "";
+    }
+    if (object.address !== undefined && object.address !== null) {
+      message.address = object.address;
+    } else {
+      message.address = "";
+    }
+    if (object.decisionPolicy !== undefined && object.decisionPolicy !== null) {
+      message.decisionPolicy = Any.fromPartial(object.decisionPolicy);
+    } else {
+      message.decisionPolicy = undefined;
+    }
+    return message;
+  },
+};
+
+const baseMsgUpdateGroupAccountDecisionPolicyResponse: object = {};
+
+export const MsgUpdateGroupAccountDecisionPolicyResponse = {
+  encode(
+    _: MsgUpdateGroupAccountDecisionPolicyResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): MsgUpdateGroupAccountDecisionPolicyResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseMsgUpdateGroupAccountDecisionPolicyResponse,
+    } as MsgUpdateGroupAccountDecisionPolicyResponse;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgUpdateGroupAccountDecisionPolicyResponse {
+    const message = {
+      ...baseMsgUpdateGroupAccountDecisionPolicyResponse,
+    } as MsgUpdateGroupAccountDecisionPolicyResponse;
+    return message;
+  },
+
+  toJSON(_: MsgUpdateGroupAccountDecisionPolicyResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial(
+    _: DeepPartial<MsgUpdateGroupAccountDecisionPolicyResponse>
+  ): MsgUpdateGroupAccountDecisionPolicyResponse {
+    const message = {
+      ...baseMsgUpdateGroupAccountDecisionPolicyResponse,
+    } as MsgUpdateGroupAccountDecisionPolicyResponse;
+    return message;
+  },
+};
+
+const baseMsgUpdateGroupAccountMetadata: object = { admin: "", address: "" };
+
+export const MsgUpdateGroupAccountMetadata = {
+  encode(
+    message: MsgUpdateGroupAccountMetadata,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.admin !== "") {
+      writer.uint32(10).string(message.admin);
+    }
+    if (message.address !== "") {
+      writer.uint32(18).string(message.address);
+    }
+    if (message.metadata.length !== 0) {
+      writer.uint32(26).bytes(message.metadata);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): MsgUpdateGroupAccountMetadata {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseMsgUpdateGroupAccountMetadata,
+    } as MsgUpdateGroupAccountMetadata;
+    message.metadata = new Uint8Array();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.admin = reader.string();
+          break;
+        case 2:
+          message.address = reader.string();
+          break;
+        case 3:
+          message.metadata = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgUpdateGroupAccountMetadata {
+    const message = {
+      ...baseMsgUpdateGroupAccountMetadata,
+    } as MsgUpdateGroupAccountMetadata;
+    message.metadata = new Uint8Array();
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = String(object.admin);
+    } else {
+      message.admin = "";
+    }
+    if (object.address !== undefined && object.address !== null) {
+      message.address = String(object.address);
+    } else {
+      message.address = "";
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = bytesFromBase64(object.metadata);
+    }
+    return message;
+  },
+
+  toJSON(message: MsgUpdateGroupAccountMetadata): unknown {
+    const obj: any = {};
+    message.admin !== undefined && (obj.admin = message.admin);
+    message.address !== undefined && (obj.address = message.address);
+    message.metadata !== undefined &&
+      (obj.metadata = base64FromBytes(
+        message.metadata !== undefined ? message.metadata : new Uint8Array()
+      ));
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<MsgUpdateGroupAccountMetadata>
+  ): MsgUpdateGroupAccountMetadata {
+    const message = {
+      ...baseMsgUpdateGroupAccountMetadata,
+    } as MsgUpdateGroupAccountMetadata;
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = object.admin;
+    } else {
+      message.admin = "";
+    }
+    if (object.address !== undefined && object.address !== null) {
+      message.address = object.address;
+    } else {
+      message.address = "";
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = object.metadata;
+    } else {
+      message.metadata = new Uint8Array();
+    }
+    return message;
+  },
+};
+
+const baseMsgUpdateGroupAccountMetadataResponse: object = {};
+
+export const MsgUpdateGroupAccountMetadataResponse = {
+  encode(
+    _: MsgUpdateGroupAccountMetadataResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): MsgUpdateGroupAccountMetadataResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseMsgUpdateGroupAccountMetadataResponse,
+    } as MsgUpdateGroupAccountMetadataResponse;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgUpdateGroupAccountMetadataResponse {
+    const message = {
+      ...baseMsgUpdateGroupAccountMetadataResponse,
+    } as MsgUpdateGroupAccountMetadataResponse;
+    return message;
+  },
+
+  toJSON(_: MsgUpdateGroupAccountMetadataResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial(
+    _: DeepPartial<MsgUpdateGroupAccountMetadataResponse>
+  ): MsgUpdateGroupAccountMetadataResponse {
+    const message = {
+      ...baseMsgUpdateGroupAccountMetadataResponse,
+    } as MsgUpdateGroupAccountMetadataResponse;
+    return message;
+  },
+};
+
+const baseMsgCreateProposal: object = { address: "", proposers: "", exec: 0 };
+
+export const MsgCreateProposal = {
+  encode(
+    message: MsgCreateProposal,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.address !== "") {
+      writer.uint32(10).string(message.address);
+    }
+    for (const v of message.proposers) {
+      writer.uint32(18).string(v!);
+    }
+    if (message.metadata.length !== 0) {
+      writer.uint32(26).bytes(message.metadata);
+    }
+    for (const v of message.msgs) {
+      Any.encode(v!, writer.uint32(34).fork()).ldelim();
+    }
+    if (message.exec !== 0) {
+      writer.uint32(40).int32(message.exec);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgCreateProposal {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseMsgCreateProposal } as MsgCreateProposal;
+    message.proposers = [];
+    message.msgs = [];
+    message.metadata = new Uint8Array();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.address = reader.string();
+          break;
+        case 2:
+          message.proposers.push(reader.string());
+          break;
+        case 3:
+          message.metadata = reader.bytes();
+          break;
+        case 4:
+          message.msgs.push(Any.decode(reader, reader.uint32()));
+          break;
+        case 5:
+          message.exec = reader.int32() as any;
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgCreateProposal {
+    const message = { ...baseMsgCreateProposal } as MsgCreateProposal;
+    message.proposers = [];
+    message.msgs = [];
+    message.metadata = new Uint8Array();
+    if (object.address !== undefined && object.address !== null) {
+      message.address = String(object.address);
+    } else {
+      message.address = "";
+    }
+    if (object.proposers !== undefined && object.proposers !== null) {
+      for (const e of object.proposers) {
+        message.proposers.push(String(e));
+      }
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = bytesFromBase64(object.metadata);
+    }
+    if (object.msgs !== undefined && object.msgs !== null) {
+      for (const e of object.msgs) {
+        message.msgs.push(Any.fromJSON(e));
+      }
+    }
+    if (object.exec !== undefined && object.exec !== null) {
+      message.exec = execFromJSON(object.exec);
+    } else {
+      message.exec = 0;
+    }
+    return message;
+  },
+
+  toJSON(message: MsgCreateProposal): unknown {
+    const obj: any = {};
+    message.address !== undefined && (obj.address = message.address);
+    if (message.proposers) {
+      obj.proposers = message.proposers.map((e) => e);
+    } else {
+      obj.proposers = [];
+    }
+    message.metadata !== undefined &&
+      (obj.metadata = base64FromBytes(
+        message.metadata !== undefined ? message.metadata : new Uint8Array()
+      ));
+    if (message.msgs) {
+      obj.msgs = message.msgs.map((e) => (e ? Any.toJSON(e) : undefined));
+    } else {
+      obj.msgs = [];
+    }
+    message.exec !== undefined && (obj.exec = execToJSON(message.exec));
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<MsgCreateProposal>): MsgCreateProposal {
+    const message = { ...baseMsgCreateProposal } as MsgCreateProposal;
+    message.proposers = [];
+    message.msgs = [];
+    if (object.address !== undefined && object.address !== null) {
+      message.address = object.address;
+    } else {
+      message.address = "";
+    }
+    if (object.proposers !== undefined && object.proposers !== null) {
+      for (const e of object.proposers) {
+        message.proposers.push(e);
+      }
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = object.metadata;
+    } else {
+      message.metadata = new Uint8Array();
+    }
+    if (object.msgs !== undefined && object.msgs !== null) {
+      for (const e of object.msgs) {
+        message.msgs.push(Any.fromPartial(e));
+      }
+    }
+    if (object.exec !== undefined && object.exec !== null) {
+      message.exec = object.exec;
+    } else {
+      message.exec = 0;
+    }
+    return message;
+  },
+};
+
+const baseMsgCreateProposalResponse: object = { proposalId: Long.UZERO };
+
+export const MsgCreateProposalResponse = {
+  encode(
+    message: MsgCreateProposalResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (!message.proposalId.isZero()) {
+      writer.uint32(8).uint64(message.proposalId);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): MsgCreateProposalResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseMsgCreateProposalResponse,
+    } as MsgCreateProposalResponse;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.proposalId = reader.uint64() as Long;
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgCreateProposalResponse {
+    const message = {
+      ...baseMsgCreateProposalResponse,
+    } as MsgCreateProposalResponse;
+    if (object.proposalId !== undefined && object.proposalId !== null) {
+      message.proposalId = Long.fromString(object.proposalId);
+    } else {
+      message.proposalId = Long.UZERO;
+    }
+    return message;
+  },
+
+  toJSON(message: MsgCreateProposalResponse): unknown {
+    const obj: any = {};
+    message.proposalId !== undefined &&
+      (obj.proposalId = (message.proposalId || Long.UZERO).toString());
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<MsgCreateProposalResponse>
+  ): MsgCreateProposalResponse {
+    const message = {
+      ...baseMsgCreateProposalResponse,
+    } as MsgCreateProposalResponse;
+    if (object.proposalId !== undefined && object.proposalId !== null) {
+      message.proposalId = object.proposalId as Long;
+    } else {
+      message.proposalId = Long.UZERO;
+    }
+    return message;
+  },
+};
+
+const baseMsgVote: object = {
+  proposalId: Long.UZERO,
+  voter: "",
+  choice: 0,
+  exec: 0,
+};
+
+export const MsgVote = {
+  encode(
+    message: MsgVote,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (!message.proposalId.isZero()) {
+      writer.uint32(8).uint64(message.proposalId);
+    }
+    if (message.voter !== "") {
+      writer.uint32(18).string(message.voter);
+    }
+    if (message.choice !== 0) {
+      writer.uint32(24).int32(message.choice);
+    }
+    if (message.metadata.length !== 0) {
+      writer.uint32(34).bytes(message.metadata);
+    }
+    if (message.exec !== 0) {
+      writer.uint32(40).int32(message.exec);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgVote {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseMsgVote } as MsgVote;
+    message.metadata = new Uint8Array();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.proposalId = reader.uint64() as Long;
+          break;
+        case 2:
+          message.voter = reader.string();
+          break;
+        case 3:
+          message.choice = reader.int32() as any;
+          break;
+        case 4:
+          message.metadata = reader.bytes();
+          break;
+        case 5:
+          message.exec = reader.int32() as any;
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgVote {
+    const message = { ...baseMsgVote } as MsgVote;
+    message.metadata = new Uint8Array();
+    if (object.proposalId !== undefined && object.proposalId !== null) {
+      message.proposalId = Long.fromString(object.proposalId);
+    } else {
+      message.proposalId = Long.UZERO;
+    }
+    if (object.voter !== undefined && object.voter !== null) {
+      message.voter = String(object.voter);
+    } else {
+      message.voter = "";
+    }
+    if (object.choice !== undefined && object.choice !== null) {
+      message.choice = choiceFromJSON(object.choice);
+    } else {
+      message.choice = 0;
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = bytesFromBase64(object.metadata);
+    }
+    if (object.exec !== undefined && object.exec !== null) {
+      message.exec = execFromJSON(object.exec);
+    } else {
+      message.exec = 0;
+    }
+    return message;
+  },
+
+  toJSON(message: MsgVote): unknown {
+    const obj: any = {};
+    message.proposalId !== undefined &&
+      (obj.proposalId = (message.proposalId || Long.UZERO).toString());
+    message.voter !== undefined && (obj.voter = message.voter);
+    message.choice !== undefined && (obj.choice = choiceToJSON(message.choice));
+    message.metadata !== undefined &&
+      (obj.metadata = base64FromBytes(
+        message.metadata !== undefined ? message.metadata : new Uint8Array()
+      ));
+    message.exec !== undefined && (obj.exec = execToJSON(message.exec));
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<MsgVote>): MsgVote {
+    const message = { ...baseMsgVote } as MsgVote;
+    if (object.proposalId !== undefined && object.proposalId !== null) {
+      message.proposalId = object.proposalId as Long;
+    } else {
+      message.proposalId = Long.UZERO;
+    }
+    if (object.voter !== undefined && object.voter !== null) {
+      message.voter = object.voter;
+    } else {
+      message.voter = "";
+    }
+    if (object.choice !== undefined && object.choice !== null) {
+      message.choice = object.choice;
+    } else {
+      message.choice = 0;
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = object.metadata;
+    } else {
+      message.metadata = new Uint8Array();
+    }
+    if (object.exec !== undefined && object.exec !== null) {
+      message.exec = object.exec;
+    } else {
+      message.exec = 0;
+    }
+    return message;
+  },
+};
+
+const baseMsgVoteResponse: object = {};
+
+export const MsgVoteResponse = {
+  encode(
+    _: MsgVoteResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgVoteResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseMsgVoteResponse } as MsgVoteResponse;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgVoteResponse {
+    const message = { ...baseMsgVoteResponse } as MsgVoteResponse;
+    return message;
+  },
+
+  toJSON(_: MsgVoteResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial(_: DeepPartial<MsgVoteResponse>): MsgVoteResponse {
+    const message = { ...baseMsgVoteResponse } as MsgVoteResponse;
+    return message;
+  },
+};
+
+const baseMsgExec: object = { proposalId: Long.UZERO, signer: "" };
+
+export const MsgExec = {
+  encode(
+    message: MsgExec,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (!message.proposalId.isZero()) {
+      writer.uint32(8).uint64(message.proposalId);
+    }
+    if (message.signer !== "") {
+      writer.uint32(18).string(message.signer);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgExec {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseMsgExec } as MsgExec;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.proposalId = reader.uint64() as Long;
+          break;
+        case 2:
+          message.signer = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgExec {
+    const message = { ...baseMsgExec } as MsgExec;
+    if (object.proposalId !== undefined && object.proposalId !== null) {
+      message.proposalId = Long.fromString(object.proposalId);
+    } else {
+      message.proposalId = Long.UZERO;
+    }
+    if (object.signer !== undefined && object.signer !== null) {
+      message.signer = String(object.signer);
+    } else {
+      message.signer = "";
+    }
+    return message;
+  },
+
+  toJSON(message: MsgExec): unknown {
+    const obj: any = {};
+    message.proposalId !== undefined &&
+      (obj.proposalId = (message.proposalId || Long.UZERO).toString());
+    message.signer !== undefined && (obj.signer = message.signer);
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<MsgExec>): MsgExec {
+    const message = { ...baseMsgExec } as MsgExec;
+    if (object.proposalId !== undefined && object.proposalId !== null) {
+      message.proposalId = object.proposalId as Long;
+    } else {
+      message.proposalId = Long.UZERO;
+    }
+    if (object.signer !== undefined && object.signer !== null) {
+      message.signer = object.signer;
+    } else {
+      message.signer = "";
+    }
+    return message;
+  },
+};
+
+const baseMsgExecResponse: object = {};
+
+export const MsgExecResponse = {
+  encode(
+    _: MsgExecResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgExecResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseMsgExecResponse } as MsgExecResponse;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgExecResponse {
+    const message = { ...baseMsgExecResponse } as MsgExecResponse;
+    return message;
+  },
+
+  toJSON(_: MsgExecResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial(_: DeepPartial<MsgExecResponse>): MsgExecResponse {
+    const message = { ...baseMsgExecResponse } as MsgExecResponse;
+    return message;
+  },
+};
+
+/** Msg is the regen.group.v1alpha1 Msg service. */
+export interface Msg {
+  /** CreateGroup creates a new group with an admin account address, a list of members and some optional metadata. */
+  CreateGroup(request: MsgCreateGroup): Promise<MsgCreateGroupResponse>;
+  /** UpdateGroupMembers updates the group members with given group id and admin address. */
+  UpdateGroupMembers(
+    request: MsgUpdateGroupMembers
+  ): Promise<MsgUpdateGroupMembersResponse>;
+  /** UpdateGroupAdmin updates the group admin with given group id and previous admin address. */
+  UpdateGroupAdmin(
+    request: MsgUpdateGroupAdmin
+  ): Promise<MsgUpdateGroupAdminResponse>;
+  /** UpdateGroupMetadata updates the group metadata with given group id and admin address. */
+  UpdateGroupMetadata(
+    request: MsgUpdateGroupMetadata
+  ): Promise<MsgUpdateGroupMetadataResponse>;
+  /** CreateGroupAccount creates a new group account using given DecisionPolicy. */
+  CreateGroupAccount(
+    request: MsgCreateGroupAccount
+  ): Promise<MsgCreateGroupAccountResponse>;
+  /** UpdateGroupAccountAdmin updates a group account admin. */
+  UpdateGroupAccountAdmin(
+    request: MsgUpdateGroupAccountAdmin
+  ): Promise<MsgUpdateGroupAccountAdminResponse>;
+  /** UpdateGroupAccountDecisionPolicy allows a group account decision policy to be updated. */
+  UpdateGroupAccountDecisionPolicy(
+    request: MsgUpdateGroupAccountDecisionPolicy
+  ): Promise<MsgUpdateGroupAccountDecisionPolicyResponse>;
+  /** UpdateGroupAccountMetadata updates a group account metadata. */
+  UpdateGroupAccountMetadata(
+    request: MsgUpdateGroupAccountMetadata
+  ): Promise<MsgUpdateGroupAccountMetadataResponse>;
+  /** CreateProposal submits a new proposal. */
+  CreateProposal(
+    request: MsgCreateProposal
+  ): Promise<MsgCreateProposalResponse>;
+  /** Vote allows a voter to vote on a proposal. */
+  Vote(request: MsgVote): Promise<MsgVoteResponse>;
+  /** Exec executes a proposal. */
+  Exec(request: MsgExec): Promise<MsgExecResponse>;
+}
+
+export class MsgClientImpl implements Msg {
+  private readonly rpc: Rpc;
+  constructor(rpc: Rpc) {
+    this.rpc = rpc;
+    this.CreateGroup = this.CreateGroup.bind(this);
+    this.UpdateGroupMembers = this.UpdateGroupMembers.bind(this);
+    this.UpdateGroupAdmin = this.UpdateGroupAdmin.bind(this);
+    this.UpdateGroupMetadata = this.UpdateGroupMetadata.bind(this);
+    this.CreateGroupAccount = this.CreateGroupAccount.bind(this);
+    this.UpdateGroupAccountAdmin = this.UpdateGroupAccountAdmin.bind(this);
+    this.UpdateGroupAccountDecisionPolicy =
+      this.UpdateGroupAccountDecisionPolicy.bind(this);
+    this.UpdateGroupAccountMetadata =
+      this.UpdateGroupAccountMetadata.bind(this);
+    this.CreateProposal = this.CreateProposal.bind(this);
+    this.Vote = this.Vote.bind(this);
+    this.Exec = this.Exec.bind(this);
+  }
+  CreateGroup(request: MsgCreateGroup): Promise<MsgCreateGroupResponse> {
+    const data = MsgCreateGroup.encode(request).finish();
+    const promise = this.rpc.request(
+      "regen.group.v1alpha1.Msg",
+      "CreateGroup",
+      data
+    );
+    return promise.then((data) =>
+      MsgCreateGroupResponse.decode(new _m0.Reader(data))
+    );
+  }
+
+  UpdateGroupMembers(
+    request: MsgUpdateGroupMembers
+  ): Promise<MsgUpdateGroupMembersResponse> {
+    const data = MsgUpdateGroupMembers.encode(request).finish();
+    const promise = this.rpc.request(
+      "regen.group.v1alpha1.Msg",
+      "UpdateGroupMembers",
+      data
+    );
+    return promise.then((data) =>
+      MsgUpdateGroupMembersResponse.decode(new _m0.Reader(data))
+    );
+  }
+
+  UpdateGroupAdmin(
+    request: MsgUpdateGroupAdmin
+  ): Promise<MsgUpdateGroupAdminResponse> {
+    const data = MsgUpdateGroupAdmin.encode(request).finish();
+    const promise = this.rpc.request(
+      "regen.group.v1alpha1.Msg",
+      "UpdateGroupAdmin",
+      data
+    );
+    return promise.then((data) =>
+      MsgUpdateGroupAdminResponse.decode(new _m0.Reader(data))
+    );
+  }
+
+  UpdateGroupMetadata(
+    request: MsgUpdateGroupMetadata
+  ): Promise<MsgUpdateGroupMetadataResponse> {
+    const data = MsgUpdateGroupMetadata.encode(request).finish();
+    const promise = this.rpc.request(
+      "regen.group.v1alpha1.Msg",
+      "UpdateGroupMetadata",
+      data
+    );
+    return promise.then((data) =>
+      MsgUpdateGroupMetadataResponse.decode(new _m0.Reader(data))
+    );
+  }
+
+  CreateGroupAccount(
+    request: MsgCreateGroupAccount
+  ): Promise<MsgCreateGroupAccountResponse> {
+    const data = MsgCreateGroupAccount.encode(request).finish();
+    const promise = this.rpc.request(
+      "regen.group.v1alpha1.Msg",
+      "CreateGroupAccount",
+      data
+    );
+    return promise.then((data) =>
+      MsgCreateGroupAccountResponse.decode(new _m0.Reader(data))
+    );
+  }
+
+  UpdateGroupAccountAdmin(
+    request: MsgUpdateGroupAccountAdmin
+  ): Promise<MsgUpdateGroupAccountAdminResponse> {
+    const data = MsgUpdateGroupAccountAdmin.encode(request).finish();
+    const promise = this.rpc.request(
+      "regen.group.v1alpha1.Msg",
+      "UpdateGroupAccountAdmin",
+      data
+    );
+    return promise.then((data) =>
+      MsgUpdateGroupAccountAdminResponse.decode(new _m0.Reader(data))
+    );
+  }
+
+  UpdateGroupAccountDecisionPolicy(
+    request: MsgUpdateGroupAccountDecisionPolicy
+  ): Promise<MsgUpdateGroupAccountDecisionPolicyResponse> {
+    const data = MsgUpdateGroupAccountDecisionPolicy.encode(request).finish();
+    const promise = this.rpc.request(
+      "regen.group.v1alpha1.Msg",
+      "UpdateGroupAccountDecisionPolicy",
+      data
+    );
+    return promise.then((data) =>
+      MsgUpdateGroupAccountDecisionPolicyResponse.decode(new _m0.Reader(data))
+    );
+  }
+
+  UpdateGroupAccountMetadata(
+    request: MsgUpdateGroupAccountMetadata
+  ): Promise<MsgUpdateGroupAccountMetadataResponse> {
+    const data = MsgUpdateGroupAccountMetadata.encode(request).finish();
+    const promise = this.rpc.request(
+      "regen.group.v1alpha1.Msg",
+      "UpdateGroupAccountMetadata",
+      data
+    );
+    return promise.then((data) =>
+      MsgUpdateGroupAccountMetadataResponse.decode(new _m0.Reader(data))
+    );
+  }
+
+  CreateProposal(
+    request: MsgCreateProposal
+  ): Promise<MsgCreateProposalResponse> {
+    const data = MsgCreateProposal.encode(request).finish();
+    const promise = this.rpc.request(
+      "regen.group.v1alpha1.Msg",
+      "CreateProposal",
+      data
+    );
+    return promise.then((data) =>
+      MsgCreateProposalResponse.decode(new _m0.Reader(data))
+    );
+  }
+
+  Vote(request: MsgVote): Promise<MsgVoteResponse> {
+    const data = MsgVote.encode(request).finish();
+    const promise = this.rpc.request("regen.group.v1alpha1.Msg", "Vote", data);
+    return promise.then((data) => MsgVoteResponse.decode(new _m0.Reader(data)));
+  }
+
+  Exec(request: MsgExec): Promise<MsgExecResponse> {
+    const data = MsgExec.encode(request).finish();
+    const promise = this.rpc.request("regen.group.v1alpha1.Msg", "Exec", data);
+    return promise.then((data) => MsgExecResponse.decode(new _m0.Reader(data)));
+  }
+}
+
+interface Rpc {
+  request(
+    service: string,
+    method: string,
+    data: Uint8Array
+  ): Promise<Uint8Array>;
+}
+
+declare var self: any | undefined;
+declare var window: any | undefined;
+declare var global: any | undefined;
+var globalThis: any = (() => {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw "Unable to locate global object";
+})();
+
+const atob: (b64: string) => string =
+  globalThis.atob ||
+  ((b64) => globalThis.Buffer.from(b64, "base64").toString("binary"));
+function bytesFromBase64(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const arr = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; ++i) {
+    arr[i] = bin.charCodeAt(i);
+  }
+  return arr;
+}
+
+const btoa: (bin: string) => string =
+  globalThis.btoa ||
+  ((bin) => globalThis.Buffer.from(bin, "binary").toString("base64"));
+function base64FromBytes(arr: Uint8Array): string {
+  const bin: string[] = [];
+  for (const byte of arr) {
+    bin.push(String.fromCharCode(byte));
+  }
+  return btoa(bin.join(""));
+}
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined
+  | Long;
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : T extends {}
+  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}

--- a/src/regen/group/v1alpha1/types.ts
+++ b/src/regen/group/v1alpha1/types.ts
@@ -1,0 +1,1663 @@
+/* eslint-disable */
+import Long from "long";
+import _m0 from "protobufjs/minimal";
+import { Duration } from "../../../google/protobuf/duration";
+import { Any } from "../../../google/protobuf/any";
+import { Timestamp } from "../../../google/protobuf/timestamp";
+
+export const protobufPackage = "regen.group.v1alpha1";
+
+/** Choice defines available types of choices for voting. */
+export enum Choice {
+  /** CHOICE_UNSPECIFIED - CHOICE_UNSPECIFIED defines a no-op voting choice. */
+  CHOICE_UNSPECIFIED = 0,
+  /** CHOICE_NO - CHOICE_NO defines a no voting choice. */
+  CHOICE_NO = 1,
+  /** CHOICE_YES - CHOICE_YES defines a yes voting choice. */
+  CHOICE_YES = 2,
+  /** CHOICE_ABSTAIN - CHOICE_ABSTAIN defines an abstaining voting choice. */
+  CHOICE_ABSTAIN = 3,
+  /** CHOICE_VETO - CHOICE_VETO defines a voting choice with veto. */
+  CHOICE_VETO = 4,
+  UNRECOGNIZED = -1,
+}
+
+export function choiceFromJSON(object: any): Choice {
+  switch (object) {
+    case 0:
+    case "CHOICE_UNSPECIFIED":
+      return Choice.CHOICE_UNSPECIFIED;
+    case 1:
+    case "CHOICE_NO":
+      return Choice.CHOICE_NO;
+    case 2:
+    case "CHOICE_YES":
+      return Choice.CHOICE_YES;
+    case 3:
+    case "CHOICE_ABSTAIN":
+      return Choice.CHOICE_ABSTAIN;
+    case 4:
+    case "CHOICE_VETO":
+      return Choice.CHOICE_VETO;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return Choice.UNRECOGNIZED;
+  }
+}
+
+export function choiceToJSON(object: Choice): string {
+  switch (object) {
+    case Choice.CHOICE_UNSPECIFIED:
+      return "CHOICE_UNSPECIFIED";
+    case Choice.CHOICE_NO:
+      return "CHOICE_NO";
+    case Choice.CHOICE_YES:
+      return "CHOICE_YES";
+    case Choice.CHOICE_ABSTAIN:
+      return "CHOICE_ABSTAIN";
+    case Choice.CHOICE_VETO:
+      return "CHOICE_VETO";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+/**
+ * Member represents a group member with an account address,
+ * non-zero weight and metadata.
+ */
+export interface Member {
+  /** address is the member's account address. */
+  address: string;
+  /** weight is the member's voting weight that should be greater than 0. */
+  weight: string;
+  /** metadata is any arbitrary metadata to attached to the member. */
+  metadata: Uint8Array;
+}
+
+/** Members defines a repeated slice of Member objects. */
+export interface Members {
+  /** members is the list of members. */
+  members: Member[];
+}
+
+/** ThresholdDecisionPolicy implements the DecisionPolicy interface */
+export interface ThresholdDecisionPolicy {
+  /** threshold is the minimum weighted sum of yes votes that must be met or exceeded for a proposal to succeed. */
+  threshold: string;
+  /**
+   * timeout is the duration from submission of a proposal to the end of voting period
+   * Within this times votes and exec messages can be submitted.
+   */
+  timeout?: Duration;
+}
+
+/** GroupInfo represents the high-level on-chain information for a group. */
+export interface GroupInfo {
+  /** group_id is the unique ID of the group. */
+  groupId: Long;
+  /** admin is the account address of the group's admin. */
+  admin: string;
+  /** metadata is any arbitrary metadata to attached to the group. */
+  metadata: Uint8Array;
+  /**
+   * version is used to track changes to a group's membership structure that
+   * would break existing proposals. Whenever any members weight is changed,
+   * or any member is added or removed this version is incremented and will
+   * cause proposals based on older versions of this group to fail
+   */
+  version: Long;
+  /** total_weight is the sum of the group members' weights. */
+  totalWeight: string;
+}
+
+/** GroupMember represents the relationship between a group and a member. */
+export interface GroupMember {
+  /** group_id is the unique ID of the group. */
+  groupId: Long;
+  /** member is the member data. */
+  member?: Member;
+}
+
+/** GroupAccountInfo represents the high-level on-chain information for a group account. */
+export interface GroupAccountInfo {
+  /** address is the group account address. */
+  address: string;
+  /** group_id is the unique ID of the group. */
+  groupId: Long;
+  /** admin is the account address of the group admin. */
+  admin: string;
+  /** metadata is any arbitrary metadata to attached to the group account. */
+  metadata: Uint8Array;
+  /**
+   * version is used to track changes to a group's GroupAccountInfo structure that
+   * would create a different result on a running proposal.
+   */
+  version: Long;
+  /** decision_policy specifies the group account's decision policy. */
+  decisionPolicy?: Any;
+  /**
+   * derivation_key is the "derivation" key of the group account,
+   * which is needed to derive the group root module key and execute proposals.
+   */
+  derivationKey: Uint8Array;
+}
+
+/**
+ * Proposal defines a group proposal. Any member of a group can submit a proposal
+ * for a group account to decide upon.
+ * A proposal consists of a set of `sdk.Msg`s that will be executed if the proposal
+ * passes as well as some optional metadata associated with the proposal.
+ */
+export interface Proposal {
+  /** proposal_id is the unique id of the proposal. */
+  proposalId: Long;
+  /** address is the group account address. */
+  address: string;
+  /** metadata is any arbitrary metadata to attached to the proposal. */
+  metadata: Uint8Array;
+  /** proposers are the account addresses of the proposers. */
+  proposers: string[];
+  /** submitted_at is a timestamp specifying when a proposal was submitted. */
+  submittedAt?: Date;
+  /**
+   * group_version tracks the version of the group that this proposal corresponds to.
+   * When group membership is changed, existing proposals from previous group versions will become invalid.
+   */
+  groupVersion: Long;
+  /**
+   * group_account_version tracks the version of the group account that this proposal corresponds to.
+   * When a decision policy is changed, existing proposals from previous policy versions will become invalid.
+   */
+  groupAccountVersion: Long;
+  /** Status represents the high level position in the life cycle of the proposal. Initial value is Submitted. */
+  status: Proposal_Status;
+  /**
+   * result is the final result based on the votes and election rule. Initial value is unfinalized.
+   * The result is persisted so that clients can always rely on this state and not have to replicate the logic.
+   */
+  result: Proposal_Result;
+  /** vote_state contains the sums of all weighted votes for this proposal. */
+  voteState?: Tally;
+  /**
+   * timeout is the timestamp of the block where the proposal execution times out. Header times of the votes and execution messages
+   * must be before this end time to be included in the election. After the timeout timestamp the proposal can not be
+   * executed anymore and should be considered pending delete.
+   */
+  timeout?: Date;
+  /** executor_result is the final result based on the votes and election rule. Initial value is NotRun. */
+  executorResult: Proposal_ExecutorResult;
+  /** msgs is a list of Msgs that will be executed if the proposal passes. */
+  msgs: Any[];
+}
+
+/** Status defines proposal statuses. */
+export enum Proposal_Status {
+  /** STATUS_UNSPECIFIED - An empty value is invalid and not allowed. */
+  STATUS_UNSPECIFIED = 0,
+  /** STATUS_SUBMITTED - Initial status of a proposal when persisted. */
+  STATUS_SUBMITTED = 1,
+  /** STATUS_CLOSED - Final status of a proposal when the final tally was executed. */
+  STATUS_CLOSED = 2,
+  /** STATUS_ABORTED - Final status of a proposal when the group was modified before the final tally. */
+  STATUS_ABORTED = 3,
+  UNRECOGNIZED = -1,
+}
+
+export function proposal_StatusFromJSON(object: any): Proposal_Status {
+  switch (object) {
+    case 0:
+    case "STATUS_UNSPECIFIED":
+      return Proposal_Status.STATUS_UNSPECIFIED;
+    case 1:
+    case "STATUS_SUBMITTED":
+      return Proposal_Status.STATUS_SUBMITTED;
+    case 2:
+    case "STATUS_CLOSED":
+      return Proposal_Status.STATUS_CLOSED;
+    case 3:
+    case "STATUS_ABORTED":
+      return Proposal_Status.STATUS_ABORTED;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return Proposal_Status.UNRECOGNIZED;
+  }
+}
+
+export function proposal_StatusToJSON(object: Proposal_Status): string {
+  switch (object) {
+    case Proposal_Status.STATUS_UNSPECIFIED:
+      return "STATUS_UNSPECIFIED";
+    case Proposal_Status.STATUS_SUBMITTED:
+      return "STATUS_SUBMITTED";
+    case Proposal_Status.STATUS_CLOSED:
+      return "STATUS_CLOSED";
+    case Proposal_Status.STATUS_ABORTED:
+      return "STATUS_ABORTED";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+/** Result defines types of proposal results. */
+export enum Proposal_Result {
+  /** RESULT_UNSPECIFIED - An empty value is invalid and not allowed */
+  RESULT_UNSPECIFIED = 0,
+  /** RESULT_UNFINALIZED - Until a final tally has happened the status is unfinalized */
+  RESULT_UNFINALIZED = 1,
+  /** RESULT_ACCEPTED - Final result of the tally */
+  RESULT_ACCEPTED = 2,
+  /** RESULT_REJECTED - Final result of the tally */
+  RESULT_REJECTED = 3,
+  UNRECOGNIZED = -1,
+}
+
+export function proposal_ResultFromJSON(object: any): Proposal_Result {
+  switch (object) {
+    case 0:
+    case "RESULT_UNSPECIFIED":
+      return Proposal_Result.RESULT_UNSPECIFIED;
+    case 1:
+    case "RESULT_UNFINALIZED":
+      return Proposal_Result.RESULT_UNFINALIZED;
+    case 2:
+    case "RESULT_ACCEPTED":
+      return Proposal_Result.RESULT_ACCEPTED;
+    case 3:
+    case "RESULT_REJECTED":
+      return Proposal_Result.RESULT_REJECTED;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return Proposal_Result.UNRECOGNIZED;
+  }
+}
+
+export function proposal_ResultToJSON(object: Proposal_Result): string {
+  switch (object) {
+    case Proposal_Result.RESULT_UNSPECIFIED:
+      return "RESULT_UNSPECIFIED";
+    case Proposal_Result.RESULT_UNFINALIZED:
+      return "RESULT_UNFINALIZED";
+    case Proposal_Result.RESULT_ACCEPTED:
+      return "RESULT_ACCEPTED";
+    case Proposal_Result.RESULT_REJECTED:
+      return "RESULT_REJECTED";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+/** ExecutorResult defines types of proposal executor results. */
+export enum Proposal_ExecutorResult {
+  /** EXECUTOR_RESULT_UNSPECIFIED - An empty value is not allowed. */
+  EXECUTOR_RESULT_UNSPECIFIED = 0,
+  /** EXECUTOR_RESULT_NOT_RUN - We have not yet run the executor. */
+  EXECUTOR_RESULT_NOT_RUN = 1,
+  /** EXECUTOR_RESULT_SUCCESS - The executor was successful and proposed action updated state. */
+  EXECUTOR_RESULT_SUCCESS = 2,
+  /** EXECUTOR_RESULT_FAILURE - The executor returned an error and proposed action didn't update state. */
+  EXECUTOR_RESULT_FAILURE = 3,
+  UNRECOGNIZED = -1,
+}
+
+export function proposal_ExecutorResultFromJSON(
+  object: any
+): Proposal_ExecutorResult {
+  switch (object) {
+    case 0:
+    case "EXECUTOR_RESULT_UNSPECIFIED":
+      return Proposal_ExecutorResult.EXECUTOR_RESULT_UNSPECIFIED;
+    case 1:
+    case "EXECUTOR_RESULT_NOT_RUN":
+      return Proposal_ExecutorResult.EXECUTOR_RESULT_NOT_RUN;
+    case 2:
+    case "EXECUTOR_RESULT_SUCCESS":
+      return Proposal_ExecutorResult.EXECUTOR_RESULT_SUCCESS;
+    case 3:
+    case "EXECUTOR_RESULT_FAILURE":
+      return Proposal_ExecutorResult.EXECUTOR_RESULT_FAILURE;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return Proposal_ExecutorResult.UNRECOGNIZED;
+  }
+}
+
+export function proposal_ExecutorResultToJSON(
+  object: Proposal_ExecutorResult
+): string {
+  switch (object) {
+    case Proposal_ExecutorResult.EXECUTOR_RESULT_UNSPECIFIED:
+      return "EXECUTOR_RESULT_UNSPECIFIED";
+    case Proposal_ExecutorResult.EXECUTOR_RESULT_NOT_RUN:
+      return "EXECUTOR_RESULT_NOT_RUN";
+    case Proposal_ExecutorResult.EXECUTOR_RESULT_SUCCESS:
+      return "EXECUTOR_RESULT_SUCCESS";
+    case Proposal_ExecutorResult.EXECUTOR_RESULT_FAILURE:
+      return "EXECUTOR_RESULT_FAILURE";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+/** Tally represents the sum of weighted votes. */
+export interface Tally {
+  /** yes_count is the weighted sum of yes votes. */
+  yesCount: string;
+  /** no_count is the weighted sum of no votes. */
+  noCount: string;
+  /** abstain_count is the weighted sum of abstainers */
+  abstainCount: string;
+  /** veto_count is the weighted sum of vetoes. */
+  vetoCount: string;
+}
+
+/** Vote represents a vote for a proposal. */
+export interface Vote {
+  /** proposal is the unique ID of the proposal. */
+  proposalId: Long;
+  /** voter is the account address of the voter. */
+  voter: string;
+  /** choice is the voter's choice on the proposal. */
+  choice: Choice;
+  /** metadata is any arbitrary metadata to attached to the vote. */
+  metadata: Uint8Array;
+  /** submitted_at is the timestamp when the vote was submitted. */
+  submittedAt?: Date;
+}
+
+const baseMember: object = { address: "", weight: "" };
+
+export const Member = {
+  encode(
+    message: Member,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.address !== "") {
+      writer.uint32(10).string(message.address);
+    }
+    if (message.weight !== "") {
+      writer.uint32(18).string(message.weight);
+    }
+    if (message.metadata.length !== 0) {
+      writer.uint32(26).bytes(message.metadata);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Member {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseMember } as Member;
+    message.metadata = new Uint8Array();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.address = reader.string();
+          break;
+        case 2:
+          message.weight = reader.string();
+          break;
+        case 3:
+          message.metadata = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Member {
+    const message = { ...baseMember } as Member;
+    message.metadata = new Uint8Array();
+    if (object.address !== undefined && object.address !== null) {
+      message.address = String(object.address);
+    } else {
+      message.address = "";
+    }
+    if (object.weight !== undefined && object.weight !== null) {
+      message.weight = String(object.weight);
+    } else {
+      message.weight = "";
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = bytesFromBase64(object.metadata);
+    }
+    return message;
+  },
+
+  toJSON(message: Member): unknown {
+    const obj: any = {};
+    message.address !== undefined && (obj.address = message.address);
+    message.weight !== undefined && (obj.weight = message.weight);
+    message.metadata !== undefined &&
+      (obj.metadata = base64FromBytes(
+        message.metadata !== undefined ? message.metadata : new Uint8Array()
+      ));
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<Member>): Member {
+    const message = { ...baseMember } as Member;
+    if (object.address !== undefined && object.address !== null) {
+      message.address = object.address;
+    } else {
+      message.address = "";
+    }
+    if (object.weight !== undefined && object.weight !== null) {
+      message.weight = object.weight;
+    } else {
+      message.weight = "";
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = object.metadata;
+    } else {
+      message.metadata = new Uint8Array();
+    }
+    return message;
+  },
+};
+
+const baseMembers: object = {};
+
+export const Members = {
+  encode(
+    message: Members,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    for (const v of message.members) {
+      Member.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Members {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseMembers } as Members;
+    message.members = [];
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.members.push(Member.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Members {
+    const message = { ...baseMembers } as Members;
+    message.members = [];
+    if (object.members !== undefined && object.members !== null) {
+      for (const e of object.members) {
+        message.members.push(Member.fromJSON(e));
+      }
+    }
+    return message;
+  },
+
+  toJSON(message: Members): unknown {
+    const obj: any = {};
+    if (message.members) {
+      obj.members = message.members.map((e) =>
+        e ? Member.toJSON(e) : undefined
+      );
+    } else {
+      obj.members = [];
+    }
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<Members>): Members {
+    const message = { ...baseMembers } as Members;
+    message.members = [];
+    if (object.members !== undefined && object.members !== null) {
+      for (const e of object.members) {
+        message.members.push(Member.fromPartial(e));
+      }
+    }
+    return message;
+  },
+};
+
+const baseThresholdDecisionPolicy: object = { threshold: "" };
+
+export const ThresholdDecisionPolicy = {
+  encode(
+    message: ThresholdDecisionPolicy,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.threshold !== "") {
+      writer.uint32(10).string(message.threshold);
+    }
+    if (message.timeout !== undefined) {
+      Duration.encode(message.timeout, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): ThresholdDecisionPolicy {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseThresholdDecisionPolicy,
+    } as ThresholdDecisionPolicy;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.threshold = reader.string();
+          break;
+        case 2:
+          message.timeout = Duration.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ThresholdDecisionPolicy {
+    const message = {
+      ...baseThresholdDecisionPolicy,
+    } as ThresholdDecisionPolicy;
+    if (object.threshold !== undefined && object.threshold !== null) {
+      message.threshold = String(object.threshold);
+    } else {
+      message.threshold = "";
+    }
+    if (object.timeout !== undefined && object.timeout !== null) {
+      message.timeout = Duration.fromJSON(object.timeout);
+    } else {
+      message.timeout = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: ThresholdDecisionPolicy): unknown {
+    const obj: any = {};
+    message.threshold !== undefined && (obj.threshold = message.threshold);
+    message.timeout !== undefined &&
+      (obj.timeout = message.timeout
+        ? Duration.toJSON(message.timeout)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial(
+    object: DeepPartial<ThresholdDecisionPolicy>
+  ): ThresholdDecisionPolicy {
+    const message = {
+      ...baseThresholdDecisionPolicy,
+    } as ThresholdDecisionPolicy;
+    if (object.threshold !== undefined && object.threshold !== null) {
+      message.threshold = object.threshold;
+    } else {
+      message.threshold = "";
+    }
+    if (object.timeout !== undefined && object.timeout !== null) {
+      message.timeout = Duration.fromPartial(object.timeout);
+    } else {
+      message.timeout = undefined;
+    }
+    return message;
+  },
+};
+
+const baseGroupInfo: object = {
+  groupId: Long.UZERO,
+  admin: "",
+  version: Long.UZERO,
+  totalWeight: "",
+};
+
+export const GroupInfo = {
+  encode(
+    message: GroupInfo,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (!message.groupId.isZero()) {
+      writer.uint32(8).uint64(message.groupId);
+    }
+    if (message.admin !== "") {
+      writer.uint32(18).string(message.admin);
+    }
+    if (message.metadata.length !== 0) {
+      writer.uint32(26).bytes(message.metadata);
+    }
+    if (!message.version.isZero()) {
+      writer.uint32(32).uint64(message.version);
+    }
+    if (message.totalWeight !== "") {
+      writer.uint32(42).string(message.totalWeight);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): GroupInfo {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseGroupInfo } as GroupInfo;
+    message.metadata = new Uint8Array();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.groupId = reader.uint64() as Long;
+          break;
+        case 2:
+          message.admin = reader.string();
+          break;
+        case 3:
+          message.metadata = reader.bytes();
+          break;
+        case 4:
+          message.version = reader.uint64() as Long;
+          break;
+        case 5:
+          message.totalWeight = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GroupInfo {
+    const message = { ...baseGroupInfo } as GroupInfo;
+    message.metadata = new Uint8Array();
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = Long.fromString(object.groupId);
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = String(object.admin);
+    } else {
+      message.admin = "";
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = bytesFromBase64(object.metadata);
+    }
+    if (object.version !== undefined && object.version !== null) {
+      message.version = Long.fromString(object.version);
+    } else {
+      message.version = Long.UZERO;
+    }
+    if (object.totalWeight !== undefined && object.totalWeight !== null) {
+      message.totalWeight = String(object.totalWeight);
+    } else {
+      message.totalWeight = "";
+    }
+    return message;
+  },
+
+  toJSON(message: GroupInfo): unknown {
+    const obj: any = {};
+    message.groupId !== undefined &&
+      (obj.groupId = (message.groupId || Long.UZERO).toString());
+    message.admin !== undefined && (obj.admin = message.admin);
+    message.metadata !== undefined &&
+      (obj.metadata = base64FromBytes(
+        message.metadata !== undefined ? message.metadata : new Uint8Array()
+      ));
+    message.version !== undefined &&
+      (obj.version = (message.version || Long.UZERO).toString());
+    message.totalWeight !== undefined &&
+      (obj.totalWeight = message.totalWeight);
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<GroupInfo>): GroupInfo {
+    const message = { ...baseGroupInfo } as GroupInfo;
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = object.groupId as Long;
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = object.admin;
+    } else {
+      message.admin = "";
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = object.metadata;
+    } else {
+      message.metadata = new Uint8Array();
+    }
+    if (object.version !== undefined && object.version !== null) {
+      message.version = object.version as Long;
+    } else {
+      message.version = Long.UZERO;
+    }
+    if (object.totalWeight !== undefined && object.totalWeight !== null) {
+      message.totalWeight = object.totalWeight;
+    } else {
+      message.totalWeight = "";
+    }
+    return message;
+  },
+};
+
+const baseGroupMember: object = { groupId: Long.UZERO };
+
+export const GroupMember = {
+  encode(
+    message: GroupMember,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (!message.groupId.isZero()) {
+      writer.uint32(8).uint64(message.groupId);
+    }
+    if (message.member !== undefined) {
+      Member.encode(message.member, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): GroupMember {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseGroupMember } as GroupMember;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.groupId = reader.uint64() as Long;
+          break;
+        case 2:
+          message.member = Member.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GroupMember {
+    const message = { ...baseGroupMember } as GroupMember;
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = Long.fromString(object.groupId);
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    if (object.member !== undefined && object.member !== null) {
+      message.member = Member.fromJSON(object.member);
+    } else {
+      message.member = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: GroupMember): unknown {
+    const obj: any = {};
+    message.groupId !== undefined &&
+      (obj.groupId = (message.groupId || Long.UZERO).toString());
+    message.member !== undefined &&
+      (obj.member = message.member ? Member.toJSON(message.member) : undefined);
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<GroupMember>): GroupMember {
+    const message = { ...baseGroupMember } as GroupMember;
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = object.groupId as Long;
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    if (object.member !== undefined && object.member !== null) {
+      message.member = Member.fromPartial(object.member);
+    } else {
+      message.member = undefined;
+    }
+    return message;
+  },
+};
+
+const baseGroupAccountInfo: object = {
+  address: "",
+  groupId: Long.UZERO,
+  admin: "",
+  version: Long.UZERO,
+};
+
+export const GroupAccountInfo = {
+  encode(
+    message: GroupAccountInfo,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.address !== "") {
+      writer.uint32(10).string(message.address);
+    }
+    if (!message.groupId.isZero()) {
+      writer.uint32(16).uint64(message.groupId);
+    }
+    if (message.admin !== "") {
+      writer.uint32(26).string(message.admin);
+    }
+    if (message.metadata.length !== 0) {
+      writer.uint32(34).bytes(message.metadata);
+    }
+    if (!message.version.isZero()) {
+      writer.uint32(40).uint64(message.version);
+    }
+    if (message.decisionPolicy !== undefined) {
+      Any.encode(message.decisionPolicy, writer.uint32(50).fork()).ldelim();
+    }
+    if (message.derivationKey.length !== 0) {
+      writer.uint32(58).bytes(message.derivationKey);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): GroupAccountInfo {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseGroupAccountInfo } as GroupAccountInfo;
+    message.metadata = new Uint8Array();
+    message.derivationKey = new Uint8Array();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.address = reader.string();
+          break;
+        case 2:
+          message.groupId = reader.uint64() as Long;
+          break;
+        case 3:
+          message.admin = reader.string();
+          break;
+        case 4:
+          message.metadata = reader.bytes();
+          break;
+        case 5:
+          message.version = reader.uint64() as Long;
+          break;
+        case 6:
+          message.decisionPolicy = Any.decode(reader, reader.uint32());
+          break;
+        case 7:
+          message.derivationKey = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GroupAccountInfo {
+    const message = { ...baseGroupAccountInfo } as GroupAccountInfo;
+    message.metadata = new Uint8Array();
+    message.derivationKey = new Uint8Array();
+    if (object.address !== undefined && object.address !== null) {
+      message.address = String(object.address);
+    } else {
+      message.address = "";
+    }
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = Long.fromString(object.groupId);
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = String(object.admin);
+    } else {
+      message.admin = "";
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = bytesFromBase64(object.metadata);
+    }
+    if (object.version !== undefined && object.version !== null) {
+      message.version = Long.fromString(object.version);
+    } else {
+      message.version = Long.UZERO;
+    }
+    if (object.decisionPolicy !== undefined && object.decisionPolicy !== null) {
+      message.decisionPolicy = Any.fromJSON(object.decisionPolicy);
+    } else {
+      message.decisionPolicy = undefined;
+    }
+    if (object.derivationKey !== undefined && object.derivationKey !== null) {
+      message.derivationKey = bytesFromBase64(object.derivationKey);
+    }
+    return message;
+  },
+
+  toJSON(message: GroupAccountInfo): unknown {
+    const obj: any = {};
+    message.address !== undefined && (obj.address = message.address);
+    message.groupId !== undefined &&
+      (obj.groupId = (message.groupId || Long.UZERO).toString());
+    message.admin !== undefined && (obj.admin = message.admin);
+    message.metadata !== undefined &&
+      (obj.metadata = base64FromBytes(
+        message.metadata !== undefined ? message.metadata : new Uint8Array()
+      ));
+    message.version !== undefined &&
+      (obj.version = (message.version || Long.UZERO).toString());
+    message.decisionPolicy !== undefined &&
+      (obj.decisionPolicy = message.decisionPolicy
+        ? Any.toJSON(message.decisionPolicy)
+        : undefined);
+    message.derivationKey !== undefined &&
+      (obj.derivationKey = base64FromBytes(
+        message.derivationKey !== undefined
+          ? message.derivationKey
+          : new Uint8Array()
+      ));
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<GroupAccountInfo>): GroupAccountInfo {
+    const message = { ...baseGroupAccountInfo } as GroupAccountInfo;
+    if (object.address !== undefined && object.address !== null) {
+      message.address = object.address;
+    } else {
+      message.address = "";
+    }
+    if (object.groupId !== undefined && object.groupId !== null) {
+      message.groupId = object.groupId as Long;
+    } else {
+      message.groupId = Long.UZERO;
+    }
+    if (object.admin !== undefined && object.admin !== null) {
+      message.admin = object.admin;
+    } else {
+      message.admin = "";
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = object.metadata;
+    } else {
+      message.metadata = new Uint8Array();
+    }
+    if (object.version !== undefined && object.version !== null) {
+      message.version = object.version as Long;
+    } else {
+      message.version = Long.UZERO;
+    }
+    if (object.decisionPolicy !== undefined && object.decisionPolicy !== null) {
+      message.decisionPolicy = Any.fromPartial(object.decisionPolicy);
+    } else {
+      message.decisionPolicy = undefined;
+    }
+    if (object.derivationKey !== undefined && object.derivationKey !== null) {
+      message.derivationKey = object.derivationKey;
+    } else {
+      message.derivationKey = new Uint8Array();
+    }
+    return message;
+  },
+};
+
+const baseProposal: object = {
+  proposalId: Long.UZERO,
+  address: "",
+  proposers: "",
+  groupVersion: Long.UZERO,
+  groupAccountVersion: Long.UZERO,
+  status: 0,
+  result: 0,
+  executorResult: 0,
+};
+
+export const Proposal = {
+  encode(
+    message: Proposal,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (!message.proposalId.isZero()) {
+      writer.uint32(8).uint64(message.proposalId);
+    }
+    if (message.address !== "") {
+      writer.uint32(18).string(message.address);
+    }
+    if (message.metadata.length !== 0) {
+      writer.uint32(26).bytes(message.metadata);
+    }
+    for (const v of message.proposers) {
+      writer.uint32(34).string(v!);
+    }
+    if (message.submittedAt !== undefined) {
+      Timestamp.encode(
+        toTimestamp(message.submittedAt),
+        writer.uint32(42).fork()
+      ).ldelim();
+    }
+    if (!message.groupVersion.isZero()) {
+      writer.uint32(48).uint64(message.groupVersion);
+    }
+    if (!message.groupAccountVersion.isZero()) {
+      writer.uint32(56).uint64(message.groupAccountVersion);
+    }
+    if (message.status !== 0) {
+      writer.uint32(64).int32(message.status);
+    }
+    if (message.result !== 0) {
+      writer.uint32(72).int32(message.result);
+    }
+    if (message.voteState !== undefined) {
+      Tally.encode(message.voteState, writer.uint32(82).fork()).ldelim();
+    }
+    if (message.timeout !== undefined) {
+      Timestamp.encode(
+        toTimestamp(message.timeout),
+        writer.uint32(90).fork()
+      ).ldelim();
+    }
+    if (message.executorResult !== 0) {
+      writer.uint32(96).int32(message.executorResult);
+    }
+    for (const v of message.msgs) {
+      Any.encode(v!, writer.uint32(106).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Proposal {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseProposal } as Proposal;
+    message.proposers = [];
+    message.msgs = [];
+    message.metadata = new Uint8Array();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.proposalId = reader.uint64() as Long;
+          break;
+        case 2:
+          message.address = reader.string();
+          break;
+        case 3:
+          message.metadata = reader.bytes();
+          break;
+        case 4:
+          message.proposers.push(reader.string());
+          break;
+        case 5:
+          message.submittedAt = fromTimestamp(
+            Timestamp.decode(reader, reader.uint32())
+          );
+          break;
+        case 6:
+          message.groupVersion = reader.uint64() as Long;
+          break;
+        case 7:
+          message.groupAccountVersion = reader.uint64() as Long;
+          break;
+        case 8:
+          message.status = reader.int32() as any;
+          break;
+        case 9:
+          message.result = reader.int32() as any;
+          break;
+        case 10:
+          message.voteState = Tally.decode(reader, reader.uint32());
+          break;
+        case 11:
+          message.timeout = fromTimestamp(
+            Timestamp.decode(reader, reader.uint32())
+          );
+          break;
+        case 12:
+          message.executorResult = reader.int32() as any;
+          break;
+        case 13:
+          message.msgs.push(Any.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Proposal {
+    const message = { ...baseProposal } as Proposal;
+    message.proposers = [];
+    message.msgs = [];
+    message.metadata = new Uint8Array();
+    if (object.proposalId !== undefined && object.proposalId !== null) {
+      message.proposalId = Long.fromString(object.proposalId);
+    } else {
+      message.proposalId = Long.UZERO;
+    }
+    if (object.address !== undefined && object.address !== null) {
+      message.address = String(object.address);
+    } else {
+      message.address = "";
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = bytesFromBase64(object.metadata);
+    }
+    if (object.proposers !== undefined && object.proposers !== null) {
+      for (const e of object.proposers) {
+        message.proposers.push(String(e));
+      }
+    }
+    if (object.submittedAt !== undefined && object.submittedAt !== null) {
+      message.submittedAt = fromJsonTimestamp(object.submittedAt);
+    } else {
+      message.submittedAt = undefined;
+    }
+    if (object.groupVersion !== undefined && object.groupVersion !== null) {
+      message.groupVersion = Long.fromString(object.groupVersion);
+    } else {
+      message.groupVersion = Long.UZERO;
+    }
+    if (
+      object.groupAccountVersion !== undefined &&
+      object.groupAccountVersion !== null
+    ) {
+      message.groupAccountVersion = Long.fromString(object.groupAccountVersion);
+    } else {
+      message.groupAccountVersion = Long.UZERO;
+    }
+    if (object.status !== undefined && object.status !== null) {
+      message.status = proposal_StatusFromJSON(object.status);
+    } else {
+      message.status = 0;
+    }
+    if (object.result !== undefined && object.result !== null) {
+      message.result = proposal_ResultFromJSON(object.result);
+    } else {
+      message.result = 0;
+    }
+    if (object.voteState !== undefined && object.voteState !== null) {
+      message.voteState = Tally.fromJSON(object.voteState);
+    } else {
+      message.voteState = undefined;
+    }
+    if (object.timeout !== undefined && object.timeout !== null) {
+      message.timeout = fromJsonTimestamp(object.timeout);
+    } else {
+      message.timeout = undefined;
+    }
+    if (object.executorResult !== undefined && object.executorResult !== null) {
+      message.executorResult = proposal_ExecutorResultFromJSON(
+        object.executorResult
+      );
+    } else {
+      message.executorResult = 0;
+    }
+    if (object.msgs !== undefined && object.msgs !== null) {
+      for (const e of object.msgs) {
+        message.msgs.push(Any.fromJSON(e));
+      }
+    }
+    return message;
+  },
+
+  toJSON(message: Proposal): unknown {
+    const obj: any = {};
+    message.proposalId !== undefined &&
+      (obj.proposalId = (message.proposalId || Long.UZERO).toString());
+    message.address !== undefined && (obj.address = message.address);
+    message.metadata !== undefined &&
+      (obj.metadata = base64FromBytes(
+        message.metadata !== undefined ? message.metadata : new Uint8Array()
+      ));
+    if (message.proposers) {
+      obj.proposers = message.proposers.map((e) => e);
+    } else {
+      obj.proposers = [];
+    }
+    message.submittedAt !== undefined &&
+      (obj.submittedAt = message.submittedAt.toISOString());
+    message.groupVersion !== undefined &&
+      (obj.groupVersion = (message.groupVersion || Long.UZERO).toString());
+    message.groupAccountVersion !== undefined &&
+      (obj.groupAccountVersion = (
+        message.groupAccountVersion || Long.UZERO
+      ).toString());
+    message.status !== undefined &&
+      (obj.status = proposal_StatusToJSON(message.status));
+    message.result !== undefined &&
+      (obj.result = proposal_ResultToJSON(message.result));
+    message.voteState !== undefined &&
+      (obj.voteState = message.voteState
+        ? Tally.toJSON(message.voteState)
+        : undefined);
+    message.timeout !== undefined &&
+      (obj.timeout = message.timeout.toISOString());
+    message.executorResult !== undefined &&
+      (obj.executorResult = proposal_ExecutorResultToJSON(
+        message.executorResult
+      ));
+    if (message.msgs) {
+      obj.msgs = message.msgs.map((e) => (e ? Any.toJSON(e) : undefined));
+    } else {
+      obj.msgs = [];
+    }
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<Proposal>): Proposal {
+    const message = { ...baseProposal } as Proposal;
+    message.proposers = [];
+    message.msgs = [];
+    if (object.proposalId !== undefined && object.proposalId !== null) {
+      message.proposalId = object.proposalId as Long;
+    } else {
+      message.proposalId = Long.UZERO;
+    }
+    if (object.address !== undefined && object.address !== null) {
+      message.address = object.address;
+    } else {
+      message.address = "";
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = object.metadata;
+    } else {
+      message.metadata = new Uint8Array();
+    }
+    if (object.proposers !== undefined && object.proposers !== null) {
+      for (const e of object.proposers) {
+        message.proposers.push(e);
+      }
+    }
+    if (object.submittedAt !== undefined && object.submittedAt !== null) {
+      message.submittedAt = object.submittedAt;
+    } else {
+      message.submittedAt = undefined;
+    }
+    if (object.groupVersion !== undefined && object.groupVersion !== null) {
+      message.groupVersion = object.groupVersion as Long;
+    } else {
+      message.groupVersion = Long.UZERO;
+    }
+    if (
+      object.groupAccountVersion !== undefined &&
+      object.groupAccountVersion !== null
+    ) {
+      message.groupAccountVersion = object.groupAccountVersion as Long;
+    } else {
+      message.groupAccountVersion = Long.UZERO;
+    }
+    if (object.status !== undefined && object.status !== null) {
+      message.status = object.status;
+    } else {
+      message.status = 0;
+    }
+    if (object.result !== undefined && object.result !== null) {
+      message.result = object.result;
+    } else {
+      message.result = 0;
+    }
+    if (object.voteState !== undefined && object.voteState !== null) {
+      message.voteState = Tally.fromPartial(object.voteState);
+    } else {
+      message.voteState = undefined;
+    }
+    if (object.timeout !== undefined && object.timeout !== null) {
+      message.timeout = object.timeout;
+    } else {
+      message.timeout = undefined;
+    }
+    if (object.executorResult !== undefined && object.executorResult !== null) {
+      message.executorResult = object.executorResult;
+    } else {
+      message.executorResult = 0;
+    }
+    if (object.msgs !== undefined && object.msgs !== null) {
+      for (const e of object.msgs) {
+        message.msgs.push(Any.fromPartial(e));
+      }
+    }
+    return message;
+  },
+};
+
+const baseTally: object = {
+  yesCount: "",
+  noCount: "",
+  abstainCount: "",
+  vetoCount: "",
+};
+
+export const Tally = {
+  encode(message: Tally, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.yesCount !== "") {
+      writer.uint32(10).string(message.yesCount);
+    }
+    if (message.noCount !== "") {
+      writer.uint32(18).string(message.noCount);
+    }
+    if (message.abstainCount !== "") {
+      writer.uint32(26).string(message.abstainCount);
+    }
+    if (message.vetoCount !== "") {
+      writer.uint32(34).string(message.vetoCount);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Tally {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseTally } as Tally;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.yesCount = reader.string();
+          break;
+        case 2:
+          message.noCount = reader.string();
+          break;
+        case 3:
+          message.abstainCount = reader.string();
+          break;
+        case 4:
+          message.vetoCount = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Tally {
+    const message = { ...baseTally } as Tally;
+    if (object.yesCount !== undefined && object.yesCount !== null) {
+      message.yesCount = String(object.yesCount);
+    } else {
+      message.yesCount = "";
+    }
+    if (object.noCount !== undefined && object.noCount !== null) {
+      message.noCount = String(object.noCount);
+    } else {
+      message.noCount = "";
+    }
+    if (object.abstainCount !== undefined && object.abstainCount !== null) {
+      message.abstainCount = String(object.abstainCount);
+    } else {
+      message.abstainCount = "";
+    }
+    if (object.vetoCount !== undefined && object.vetoCount !== null) {
+      message.vetoCount = String(object.vetoCount);
+    } else {
+      message.vetoCount = "";
+    }
+    return message;
+  },
+
+  toJSON(message: Tally): unknown {
+    const obj: any = {};
+    message.yesCount !== undefined && (obj.yesCount = message.yesCount);
+    message.noCount !== undefined && (obj.noCount = message.noCount);
+    message.abstainCount !== undefined &&
+      (obj.abstainCount = message.abstainCount);
+    message.vetoCount !== undefined && (obj.vetoCount = message.vetoCount);
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<Tally>): Tally {
+    const message = { ...baseTally } as Tally;
+    if (object.yesCount !== undefined && object.yesCount !== null) {
+      message.yesCount = object.yesCount;
+    } else {
+      message.yesCount = "";
+    }
+    if (object.noCount !== undefined && object.noCount !== null) {
+      message.noCount = object.noCount;
+    } else {
+      message.noCount = "";
+    }
+    if (object.abstainCount !== undefined && object.abstainCount !== null) {
+      message.abstainCount = object.abstainCount;
+    } else {
+      message.abstainCount = "";
+    }
+    if (object.vetoCount !== undefined && object.vetoCount !== null) {
+      message.vetoCount = object.vetoCount;
+    } else {
+      message.vetoCount = "";
+    }
+    return message;
+  },
+};
+
+const baseVote: object = { proposalId: Long.UZERO, voter: "", choice: 0 };
+
+export const Vote = {
+  encode(message: Vote, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (!message.proposalId.isZero()) {
+      writer.uint32(8).uint64(message.proposalId);
+    }
+    if (message.voter !== "") {
+      writer.uint32(18).string(message.voter);
+    }
+    if (message.choice !== 0) {
+      writer.uint32(24).int32(message.choice);
+    }
+    if (message.metadata.length !== 0) {
+      writer.uint32(34).bytes(message.metadata);
+    }
+    if (message.submittedAt !== undefined) {
+      Timestamp.encode(
+        toTimestamp(message.submittedAt),
+        writer.uint32(42).fork()
+      ).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Vote {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseVote } as Vote;
+    message.metadata = new Uint8Array();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.proposalId = reader.uint64() as Long;
+          break;
+        case 2:
+          message.voter = reader.string();
+          break;
+        case 3:
+          message.choice = reader.int32() as any;
+          break;
+        case 4:
+          message.metadata = reader.bytes();
+          break;
+        case 5:
+          message.submittedAt = fromTimestamp(
+            Timestamp.decode(reader, reader.uint32())
+          );
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Vote {
+    const message = { ...baseVote } as Vote;
+    message.metadata = new Uint8Array();
+    if (object.proposalId !== undefined && object.proposalId !== null) {
+      message.proposalId = Long.fromString(object.proposalId);
+    } else {
+      message.proposalId = Long.UZERO;
+    }
+    if (object.voter !== undefined && object.voter !== null) {
+      message.voter = String(object.voter);
+    } else {
+      message.voter = "";
+    }
+    if (object.choice !== undefined && object.choice !== null) {
+      message.choice = choiceFromJSON(object.choice);
+    } else {
+      message.choice = 0;
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = bytesFromBase64(object.metadata);
+    }
+    if (object.submittedAt !== undefined && object.submittedAt !== null) {
+      message.submittedAt = fromJsonTimestamp(object.submittedAt);
+    } else {
+      message.submittedAt = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: Vote): unknown {
+    const obj: any = {};
+    message.proposalId !== undefined &&
+      (obj.proposalId = (message.proposalId || Long.UZERO).toString());
+    message.voter !== undefined && (obj.voter = message.voter);
+    message.choice !== undefined && (obj.choice = choiceToJSON(message.choice));
+    message.metadata !== undefined &&
+      (obj.metadata = base64FromBytes(
+        message.metadata !== undefined ? message.metadata : new Uint8Array()
+      ));
+    message.submittedAt !== undefined &&
+      (obj.submittedAt = message.submittedAt.toISOString());
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<Vote>): Vote {
+    const message = { ...baseVote } as Vote;
+    if (object.proposalId !== undefined && object.proposalId !== null) {
+      message.proposalId = object.proposalId as Long;
+    } else {
+      message.proposalId = Long.UZERO;
+    }
+    if (object.voter !== undefined && object.voter !== null) {
+      message.voter = object.voter;
+    } else {
+      message.voter = "";
+    }
+    if (object.choice !== undefined && object.choice !== null) {
+      message.choice = object.choice;
+    } else {
+      message.choice = 0;
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = object.metadata;
+    } else {
+      message.metadata = new Uint8Array();
+    }
+    if (object.submittedAt !== undefined && object.submittedAt !== null) {
+      message.submittedAt = object.submittedAt;
+    } else {
+      message.submittedAt = undefined;
+    }
+    return message;
+  },
+};
+
+declare var self: any | undefined;
+declare var window: any | undefined;
+declare var global: any | undefined;
+var globalThis: any = (() => {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw "Unable to locate global object";
+})();
+
+const atob: (b64: string) => string =
+  globalThis.atob ||
+  ((b64) => globalThis.Buffer.from(b64, "base64").toString("binary"));
+function bytesFromBase64(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const arr = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; ++i) {
+    arr[i] = bin.charCodeAt(i);
+  }
+  return arr;
+}
+
+const btoa: (bin: string) => string =
+  globalThis.btoa ||
+  ((bin) => globalThis.Buffer.from(bin, "binary").toString("base64"));
+function base64FromBytes(arr: Uint8Array): string {
+  const bin: string[] = [];
+  for (const byte of arr) {
+    bin.push(String.fromCharCode(byte));
+  }
+  return btoa(bin.join(""));
+}
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined
+  | Long;
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : T extends {}
+  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+function toTimestamp(date: Date): Timestamp {
+  const seconds = numberToLong(date.getTime() / 1_000);
+  const nanos = (date.getTime() % 1_000) * 1_000_000;
+  return { seconds, nanos };
+}
+
+function fromTimestamp(t: Timestamp): Date {
+  let millis = t.seconds.toNumber() * 1_000;
+  millis += t.nanos / 1_000_000;
+  return new Date(millis);
+}
+
+function fromJsonTimestamp(o: any): Date {
+  if (o instanceof Date) {
+    return o;
+  } else if (typeof o === "string") {
+    return new Date(o);
+  } else {
+    return fromTimestamp(Timestamp.fromJSON(o));
+  }
+}
+
+function numberToLong(number: number) {
+  return Long.fromNumber(number);
+}
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}


### PR DESCRIPTION
This PR adds the new group types.

NOTE: This takes the proto files from the regen repo (https://github.com/regen-network/regen-ledger/) rather than the cosmos sdk repo because the groups module is a v0.45 feature and hasn't yet been ported across. These should be identical once it is moves across and having these types available in the cosmjs library means that developers can already start building frontends for the new feature. Once v0.45 ships, I can redirect the path from regen to the cosmos-sdk.