### PR TITLE
fix(scripts): improve portability

### DIFF
--- a/scripts/exports_protos.sh
+++ b/scripts/exports_protos.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit -o nounset -o pipefail
 command -v shellcheck >/dev/null && shellcheck "$0"
 

--- a/scripts/prepare-publishing.sh
+++ b/scripts/prepare-publishing.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit -o nounset -o pipefail
 command -v shellcheck >/dev/null && shellcheck "$0"
 


### PR DESCRIPTION
This changes the `scripts` to use `/usr/bin/env` and system `PATH` to find Bash.

Although massively widespread, IIRC Bash is not part of POSIX proper. Therefore, unlike `/bin/sh`, it can't truly be relied on to be present under `/bin` [^0]

[^0]: For example, on NixOS, `sh` is the only thing in `/bin`, and `env` is the only thing in `/usr/bin`. So, to find the `bash` executable, `/usr/bin/env` looks on the system path and resolves to e.g. `/nix/store/aw76ql7s2n8gl02swkf2i3bdn9m7qxvh-bash-interactive-5.2-p15/bin/bash` :sweat_smile: 