### PR TITLE
esm support - first attempt

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,19 +15,22 @@
   "publishConfig": {
     "access": "public"
   },
+  "exports": {
+    "./*": "./src/*.ts"
+  },
   "files": [
-    "cosmos/",
-    "cosmos_proto/",
-    "cosmwasm/",
-    "gogoproto/",
-    "google/",
-    "ibc/",
-    "tendermint/",
-    "/binary.*",
-    "/helpers.*",
-    "/utf8.*",
-    "/varint.*",
-    "/index.*",
+    "src/cosmos/",
+    "src/cosmos_proto/",
+    "src/cosmwasm/",
+    "src/gogoproto/",
+    "src/google/",
+    "src/ibc/",
+    "src/tendermint/",
+    "/src/binary.*",
+    "/src/helpers.*",
+    "/src/utf8.*",
+    "/src/varint.*",
+    "/src/index.*",
     "*.md",
     "!wasmd-*/**/*.md",
     "!cosmos-sdk-*/**/*.md"


### PR DESCRIPTION
Allows this package to be used in packages that use es modules, as per https://github.com/confio/cosmjs-types/issues/93

Since this repo seems like it might be unmaintained (maybe? last commit was 2 years ago), in lieu of this PR you can install this branch directly from github:

`package.json`:
```json
{
  "dependencies": {
    "cosmjs-types": "git://github.com/anthonyjoeseph/cosmjs-types-esm.git#main"
  }
}
```

(opened in favor of https://github.com/confio/cosmjs-types/pull/94)