### PR TITLE
remove legacy compilerOptions from tsconfig

### DIFF
--- a/scripts/codegen.js
+++ b/scripts/codegen.js
@@ -106,7 +106,7 @@ telescope({
 
     // Exports we want to provide at the root of the "cosmjs-types" package
 
-    export { DeepPartial, Exact } from "./helpers";
+    export type { DeepPartial, Exact } from "./helpers";
     `;
     writeFileSync(`${outPath}/index.ts`, index_ts);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,4 @@
 
 // Exports we want to provide at the root of the "cosmjs-types" package
 
-export { DeepPartial, Exact } from "./helpers";
+export type { DeepPartial, Exact } from "./helpers";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
     "lib": ["es2020"],
     "module": "node20",
     "newLine": "LF",


### PR DESCRIPTION
`moduleResolution=node` 'should no longer be used.'

https://www.typescriptlang.org/docs/handbook/modules/reference.html#node10-formerly-known-as-node