### PR TITLE
fix: Add exports for module compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,20 @@
   "publishConfig": {
     "access": "public"
   },
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "require": "./index.js"
+    },
+    "./*": {
+      "types": "./*.d.ts",
+      "import": "./*.js",
+      "require": "./*.js"
+    }
+  },
   "files": [
     "cosmos/",
     "cosmos_proto/",
@@ -40,8 +54,7 @@
     "prepare-publishing": "./scripts/prepare-publishing.sh",
     "build": "rm -rf ./build && tsc && npm run prepare-publishing"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "@cosmology/telescope": "^1.12.20",
     "@types/node": "^15.6.2",

--- a/package.json
+++ b/package.json
@@ -15,18 +15,17 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "./index.js",
-  "types": "./index.d.ts",
   "exports": {
     ".": {
-      "types": "./index.d.ts",
-      "import": "./index.js",
-      "require": "./index.js"
+      "types": "./index.d.ts"
     },
     "./*": {
       "types": "./*.d.ts",
-      "import": "./*.js",
-      "require": "./*.js"
+      "default": "./*.js"
+    },
+    "./*.js": {
+      "types": "./*.d.ts",
+      "default": "./*.js"
     }
   },
   "files": [


### PR DESCRIPTION
There are some open PRs for ESM support but apart from that it needs proper exports to be resolved by modern bundlers.

Once it supports dual format (esm, cjs), it just need to update like:
```json
  "exports": {
    ".": {
      "types": "./index.d.ts",
      "import": "./index.mjs",
      "require": "./index.js"
    },
    "./*": {
      "types": "./*.d.ts",
      "import": "./*.mjs",
      "require": "./*.js"
    }
  },
 ```


resolves #93